### PR TITLE
Decouple metadata caching storage to a @dedot/storage

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -16,11 +16,11 @@
     "@dedot/codecs": "workspace:*",
     "@dedot/shape": "workspace:*",
     "@dedot/specs": "workspace:*",
+    "@dedot/storage": "workspace:*",
     "@dedot/utils": "workspace:*",
     "@polkadot/rpc-provider": "^10.11.2",
     "@polkadot/util": "^12.6.2",
-    "@polkadot/util-crypto": "^12.6.2",
-    "localforage": "^1.10.0"
+    "@polkadot/util-crypto": "^12.6.2"
   },
   "scripts": {
     "build": "tsc --project tsconfig.build.json && tsc --project tsconfig.build.cjs.json",

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -2,6 +2,7 @@ import { ProviderInterface } from '@polkadot/rpc-provider/types';
 import { HexString } from '@dedot/utils';
 import { AnySignedExtension } from './extrinsic';
 import { RuntimeApiSpec } from '@dedot/types';
+import type { IStorage } from '@dedot/storage';
 
 export type NetworkEndpoint = string;
 export type MetadataKey = `RAW_META/${string}`;
@@ -22,6 +23,7 @@ export interface ApiOptions {
    * @default: false
    */
   cacheMetadata?: boolean;
+  cacheStorage?: IStorage;
   /**
    * @description Metadata is usually downloaded from chain via RPC upon API initialization,
    * We can supply the metadata directly via this option to skip the download metadata step.

--- a/packages/api/tsconfig.build.cjs.json
+++ b/packages/api/tsconfig.build.cjs.json
@@ -23,6 +23,9 @@
     },
     {
       "path": "../specs/tsconfig.json"
+    },
+    {
+      "path": "../storage/tsconfig.json"
     }
   ]
 }

--- a/packages/api/tsconfig.build.json
+++ b/packages/api/tsconfig.build.json
@@ -19,6 +19,9 @@
     },
     {
       "path": "../specs/tsconfig.json"
+    },
+    {
+      "path": "../storage/tsconfig.json"
     }
   ]
 }

--- a/packages/api/tsconfig.json
+++ b/packages/api/tsconfig.json
@@ -4,27 +4,27 @@
     "baseUrl": "./",
     "outDir": "dist",
     "rootDir": "src",
-    "declarationDir": "dist"
+    "declarationDir": "dist",
   },
   "include": ["src/**/*"],
   "references": [
     {
-      "path": "../utils/tsconfig.json"
+      "path": "../utils/tsconfig.json",
     },
     {
-      "path": "../shape/tsconfig.json"
+      "path": "../shape/tsconfig.json",
     },
     {
-      "path": "../codecs/tsconfig.json"
+      "path": "../codecs/tsconfig.json",
     },
     {
-      "path": "../types/tsconfig.json"
+      "path": "../types/tsconfig.json",
     },
     {
-      "path": "../chaintypes/tsconfig.json"
+      "path": "../chaintypes/tsconfig.json",
     },
     {
-      "path": "../specs/tsconfig.json"
-    }
-  ]
+      "path": "../storage/tsconfig.json",
+    },
+  ],
 }

--- a/packages/storage/LICENSE
+++ b/packages/storage/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/storage/README.md
+++ b/packages/storage/README.md
@@ -1,0 +1,3 @@
+# @dedot/storage
+
+ 

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@dedot/storage",
+  "version": "0.0.1-alpha.26",
+  "description": "Storage for different purposes (caching...)",
+  "author": "Thang X. Vu <thang@coongcrafts.io>",
+  "main": "src/index.ts",
+  "sideEffects": false,
+  "type": "module",
+  "scripts": {
+    "build": "tsc --project tsconfig.build.json && tsc --project tsconfig.build.cjs.json",
+    "clean": "rm -rf ./dist && rm -rf ./tsconfig.tsbuildinfo ./tsconfig.build.tsbuildinfo"
+  },
+  "publishConfig": {
+    "access": "public",
+    "directory": "dist"
+  },
+  "license": "Apache-2.0"
+}

--- a/packages/storage/src/IStorage.ts
+++ b/packages/storage/src/IStorage.ts
@@ -1,0 +1,16 @@
+/**
+ * Generic storage interface
+ */
+export interface IStorage {
+  get(key: string): Promise<string | null>;
+
+  set(key: string, value: string): Promise<string>;
+
+  remove(key: string): Promise<void>;
+
+  clear(): Promise<void>;
+
+  length(): Promise<number>;
+
+  keys(): Promise<string[]>;
+}

--- a/packages/storage/src/impl/LocalStorage.ts
+++ b/packages/storage/src/impl/LocalStorage.ts
@@ -1,0 +1,51 @@
+import type { IStorage } from '../IStorage';
+
+const checkAvailability = () => {
+  try {
+    localStorage.setItem('dedot', 'true');
+    localStorage.removeItem('dedot');
+  } catch {
+    throw new Error('localStorage is not available!');
+  }
+};
+
+/**
+ * A wrapper for localStorage
+ */
+export class LocalStorage implements IStorage {
+  constructor() {
+    checkAvailability();
+  }
+
+  async clear(): Promise<void> {
+    localStorage.clear();
+  }
+
+  async get(key: string): Promise<string | null> {
+    return localStorage.getItem(key);
+  }
+
+  async set(key: string, value: string): Promise<string> {
+    localStorage.setItem(key, value);
+    return value;
+  }
+
+  async keys(): Promise<string[]> {
+    const length = localStorage.length;
+    const keys: string[] = [];
+    for (let idx = 0; idx < length; idx += 1) {
+      const currentValue = localStorage.key(idx);
+      if (currentValue) keys.push(currentValue);
+    }
+
+    return keys;
+  }
+
+  async length(): Promise<number> {
+    return localStorage.length;
+  }
+
+  async remove(key: string): Promise<void> {
+    localStorage.removeItem(key);
+  }
+}

--- a/packages/storage/src/impl/index.ts
+++ b/packages/storage/src/impl/index.ts
@@ -1,0 +1,1 @@
+export * from './LocalStorage';

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -1,0 +1,2 @@
+export * from './IStorage';
+export * from './impl';

--- a/packages/storage/tsconfig.build.cjs.json
+++ b/packages/storage/tsconfig.build.cjs.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.build.json",
+  "compilerOptions": {
+    "outDir": "dist/cjs",
+    "module": "CommonJS"
+  },
+  "exclude": ["**/__tests__/*"]
+}

--- a/packages/storage/tsconfig.build.json
+++ b/packages/storage/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["**/__tests__/*"]
+}

--- a/packages/storage/tsconfig.json
+++ b/packages/storage/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "baseUrl": "./",
+    "outDir": "dist",
+    "rootDir": "src",
+    "declarationDir": "dist"
+  },
+  "include": ["src/**/*"]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -36,6 +36,8 @@
       "@dedot/types/*": ["../types/src/*"],
       "@dedot/utils": ["../utils/src"],
       "@dedot/utils/*": ["../utils/src/*"],
+      "@dedot/storage": ["../storage/src"],
+      "@dedot/storage/*": ["../storage/src/*"],
       "dedot": ["../api/src"],
       "dedot/*": ["../api/src/*"]
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -417,6 +417,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@dedot/storage@workspace:*, @dedot/storage@workspace:packages/storage":
+  version: 0.0.0-use.local
+  resolution: "@dedot/storage@workspace:packages/storage"
+  languageName: unknown
+  linkType: soft
+
 "@dedot/types@workspace:*, @dedot/types@workspace:packages/types":
   version: 0.0.0-use.local
   resolution: "@dedot/types@workspace:packages/types"
@@ -3423,13 +3429,13 @@ __metadata:
     "@dedot/codecs": "workspace:*"
     "@dedot/shape": "workspace:*"
     "@dedot/specs": "workspace:*"
+    "@dedot/storage": "workspace:*"
     "@dedot/utils": "workspace:*"
     "@polkadot/keyring": ^12.6.2
     "@polkadot/rpc-provider": ^10.11.2
     "@polkadot/types": ^10.11.2
     "@polkadot/util": ^12.6.2
     "@polkadot/util-crypto": ^12.6.2
-    localforage: ^1.10.0
   languageName: unknown
   linkType: soft
 
@@ -4761,13 +4767,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"immediate@npm:~3.0.5":
-  version: 3.0.6
-  resolution: "immediate@npm:3.0.6"
-  checksum: f9b3486477555997657f70318cc8d3416159f208bec4cca3ff3442fd266bc23f50f0c9bd8547e1371a6b5e82b821ec9a7044a4f7b944798b25aa3cc6d5e63e62
-  languageName: node
-  linkType: hard
-
 "import-fresh@npm:^3.2.1, import-fresh@npm:^3.3.0":
   version: 3.3.0
   resolution: "import-fresh@npm:3.3.0"
@@ -5445,15 +5444,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lie@npm:3.1.1":
-  version: 3.1.1
-  resolution: "lie@npm:3.1.1"
-  dependencies:
-    immediate: ~3.0.5
-  checksum: 6da9f2121d2dbd15f1eca44c0c7e211e66a99c7b326ec8312645f3648935bc3a658cf0e9fa7b5f10144d9e2641500b4f55bd32754607c3de945b5f443e50ddd1
-  languageName: node
-  linkType: hard
-
 "lines-and-columns@npm:^1.1.6":
   version: 1.2.4
   resolution: "lines-and-columns@npm:1.2.4"
@@ -5496,15 +5486,6 @@ __metadata:
   version: 0.4.3
   resolution: "local-pkg@npm:0.4.3"
   checksum: 7825aca531dd6afa3a3712a0208697aa4a5cd009065f32e3fb732aafcc42ed11f277b5ac67229222e96f4def55197171cdf3d5522d0381b489d2e5547b407d55
-  languageName: node
-  linkType: hard
-
-"localforage@npm:^1.10.0":
-  version: 1.10.0
-  resolution: "localforage@npm:1.10.0"
-  dependencies:
-    lie: 3.1.1
-  checksum: f2978b434dafff9bcb0d9498de57d97eba165402419939c944412e179cab1854782830b5ec196212560b22712d1dd03918939f59cf1d4fc1d756fca7950086cf
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR addresses #44 

We're now using localStorage as a default caching Storage, removing the tight coupling `localForage`, we also add a `IStorage` interface, so other means of caching can be implemented later as needed.