### PR TITLE
feat!: new @dedot/providers package with WsProvider

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@dedot/chaintypes": "0.0.1-alpha.35",
     "@dedot/codecs": "workspace:*",
+    "@dedot/providers": "workspace:^",
     "@dedot/shape": "workspace:*",
     "@dedot/specs": "workspace:*",
     "@dedot/storage": "workspace:*",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -19,8 +19,7 @@
     "@dedot/shape": "workspace:*",
     "@dedot/specs": "workspace:*",
     "@dedot/storage": "workspace:*",
-    "@dedot/utils": "workspace:*",
-    "@polkadot/rpc-provider": "^10.11.2"
+    "@dedot/utils": "workspace:*"
   },
   "scripts": {
     "build": "tsc --project tsconfig.build.json && tsc --project tsconfig.build.cjs.json",

--- a/packages/api/src/client/Dedot.ts
+++ b/packages/api/src/client/Dedot.ts
@@ -79,7 +79,6 @@ export class Dedot<ChainApi extends GenericSubstrateApi = SubstrateApi> extends 
    * Use factory methods (`create`, `new`) to create `Dedot` instances.
    *
    * @param options
-   * @protected
    */
   constructor(options: ApiOptions | NetworkEndpoint) {
     super();

--- a/packages/api/src/client/Dedot.ts
+++ b/packages/api/src/client/Dedot.ts
@@ -81,7 +81,7 @@ export class Dedot<ChainApi extends GenericSubstrateApi = SubstrateApi> extends 
    * @param options
    * @protected
    */
-  protected constructor(options: ApiOptions | NetworkEndpoint) {
+  constructor(options: ApiOptions | NetworkEndpoint) {
     super();
     this.#options = this.#normalizeOptions(options);
     this.#provider = this.#getProvider();

--- a/packages/api/src/client/Dedot.ts
+++ b/packages/api/src/client/Dedot.ts
@@ -496,6 +496,13 @@ export class Dedot<ChainApi extends GenericSubstrateApi = SubstrateApi> extends 
   }
 
   /**
+   * @description Connect to blockchain node
+   */
+  async connect() {
+    await this.#provider.connect();
+  }
+
+  /**
    * @description Disconnect to blockchain node
    */
   async disconnect() {

--- a/packages/api/src/client/Dedot.ts
+++ b/packages/api/src/client/Dedot.ts
@@ -112,6 +112,7 @@ export class Dedot<ChainApi extends GenericSubstrateApi = SubstrateApi> extends 
   async #doConnect(): Promise<this> {
     this.provider.on('connected', this.#onConnected);
     this.provider.on('disconnected', this.#onDisconnected);
+    this.provider.on('reconnecting', this.#onReconnecting);
     this.provider.on('error', this.#onError);
 
     return new Promise<this>((resolve, reject) => {
@@ -135,6 +136,10 @@ export class Dedot<ChainApi extends GenericSubstrateApi = SubstrateApi> extends 
   #onDisconnected = async () => {
     await this.#unsubscribeUpdates();
     this.emit('disconnected');
+  };
+
+  #onReconnecting = async () => {
+    this.emit('reconnecting');
   };
 
   #onError = async (e: Error) => {
@@ -492,6 +497,7 @@ export class Dedot<ChainApi extends GenericSubstrateApi = SubstrateApi> extends 
    * @description Connect to blockchain node
    */
   async connect(): Promise<this> {
+    assert(this.status !== 'connected', 'Already connected!');
     return this.#doConnect();
   }
 
@@ -500,7 +506,6 @@ export class Dedot<ChainApi extends GenericSubstrateApi = SubstrateApi> extends 
    */
   async disconnect() {
     await this.#unsubscribeUpdates();
-
     await this.#provider.disconnect();
   }
 

--- a/packages/api/src/client/__tests__/Dedot.spec.ts
+++ b/packages/api/src/client/__tests__/Dedot.spec.ts
@@ -10,7 +10,9 @@ describe('Dedot', () => {
   it('should throws error for invalid endpoint', () => {
     expect(async () => {
       await Dedot.new('invalid_endpoint');
-    }).rejects.toThrowError('Invalid RPC network endpoint, a valid endpoint should start with `wss://`, `ws://`');
+    }).rejects.toThrowError(
+      'Invalid websocket endpoint invalid_endpoint, a valid endpoint should start with wss:// or ws://',
+    );
   });
 
   describe('cache disabled', () => {

--- a/packages/api/src/client/__tests__/MockProvider.ts
+++ b/packages/api/src/client/__tests__/MockProvider.ts
@@ -12,6 +12,8 @@ import {
 import { EventEmitter } from '@dedot/utils';
 
 export default class MockProvider extends EventEmitter<ProviderEvent> implements JsonRpcProvider {
+  #status: ConnectionStatus = 'disconnected';
+
   rpcRequests: Record<string, AnyFunc> = {
     chain_getBlockHash: () => '0x0000000000000000000000000000000000000000000000000000000000000000',
     state_getRuntimeVersion: () => ({ specVersion: 1, specName: 'MockedSpec' }) as unknown as RuntimeVersion,
@@ -21,11 +23,18 @@ export default class MockProvider extends EventEmitter<ProviderEvent> implements
     state_call: () => '0x',
   };
 
+  setStatus(status: ConnectionStatus) {
+    this.#status = status;
+    this.emit(status);
+  }
+
   connect(): Promise<this> {
+    this.setStatus('connected');
     return Promise.resolve(this);
   }
 
   disconnect(): Promise<void> {
+    this.setStatus('disconnected');
     return Promise.resolve(undefined);
   }
 
@@ -50,6 +59,6 @@ export default class MockProvider extends EventEmitter<ProviderEvent> implements
   }
 
   get status(): ConnectionStatus {
-    return 'connected';
+    return this.#status;
   }
 }

--- a/packages/api/src/client/__tests__/MockProvider.ts
+++ b/packages/api/src/client/__tests__/MockProvider.ts
@@ -21,8 +21,8 @@ export default class MockProvider extends EventEmitter<ProviderEvent> implements
     state_call: () => '0x',
   };
 
-  connect(): Promise<void> {
-    return Promise.resolve(undefined);
+  connect(): Promise<this> {
+    return Promise.resolve(this);
   }
 
   disconnect(): Promise<void> {

--- a/packages/api/src/executor/RpcExecutor.ts
+++ b/packages/api/src/executor/RpcExecutor.ts
@@ -50,18 +50,16 @@ export class RpcExecutor<ChainApi extends GenericSubstrateApi = SubstrateApi> ex
       };
 
       const { params, pubsub } = callSpec;
-      const formattedInputs = inArgs.map((input, index) => this.tryEncode(params[index], input));
-      const [subname, subscribe, unsubcribe] = pubsub!;
+      const formattedParams = inArgs.map((input, index) => this.tryEncode(params[index], input));
+      const [subname, subscribe, unsubscribe] = pubsub!;
 
-      const subscription = this.provider.subscribe(subname, subscribe, formattedInputs, onNewMessage);
+      const subscription = await this.provider.subscribe(
+        { subname, subscribe, params: formattedParams, unsubscribe },
+        onNewMessage,
+      );
 
       return async () => {
-        return subscription
-          .then((subscriptionId) => this.provider.unsubscribe(subname, unsubcribe, subscriptionId))
-          .catch((err) => {
-            console.error(err);
-            return false;
-          });
+        return subscription.unsubscribe().catch(console.error);
       };
     };
 

--- a/packages/api/src/executor/RpcExecutor.ts
+++ b/packages/api/src/executor/RpcExecutor.ts
@@ -59,7 +59,7 @@ export class RpcExecutor<ChainApi extends GenericSubstrateApi = SubstrateApi> ex
       );
 
       return async () => {
-        return subscription.unsubscribe().catch(console.error);
+        await subscription.unsubscribe();
       };
     };
 

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -3,4 +3,4 @@ export type * from './types.js';
 export * from './executor/index.js';
 export * from './extrinsic/index.js';
 export { Dedot } from './client/index.js';
-export { WsProvider } from '@polkadot/rpc-provider';
+export { WsProvider } from '@dedot/providers';

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -2,7 +2,7 @@ import type { HexString } from '@dedot/utils';
 import type { AnySignedExtension } from './extrinsic/index.js';
 import type { RuntimeApiName, RuntimeApiSpec } from '@dedot/types';
 import type { IStorage } from '@dedot/storage';
-import type { JsonRpcProvider } from '@dedot/providers';
+import type { JsonRpcProvider, ProviderEvent } from '@dedot/providers';
 
 export type NetworkEndpoint = string;
 export type MetadataKey = `RAW_META/${string}`;
@@ -64,4 +64,4 @@ export interface NormalizedApiOptions extends ApiOptions {
   metadata?: Record<string, HexString>;
 }
 
-export type ApiEventNames = 'connected' | 'disconnected' | 'error' | 'ready';
+export type ApiEventNames = ProviderEvent | 'ready';

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -1,14 +1,14 @@
-import { ProviderInterface } from '@polkadot/rpc-provider/types';
-import { HexString } from '@dedot/utils';
-import { AnySignedExtension } from './extrinsic/index.js';
-import { RuntimeApiName, RuntimeApiSpec } from '@dedot/types';
+import type { HexString } from '@dedot/utils';
+import type { AnySignedExtension } from './extrinsic/index.js';
+import type { RuntimeApiName, RuntimeApiSpec } from '@dedot/types';
 import type { IStorage } from '@dedot/storage';
+import type { JsonRpcProvider } from '@dedot/providers';
 
 export type NetworkEndpoint = string;
 export type MetadataKey = `RAW_META/${string}`;
 
 export interface ApiOptions {
-  provider?: ProviderInterface;
+  provider?: JsonRpcProvider;
   /**
    * @description A `ProviderInterface` will be created based on the supplied endpoint.
    * If both `provider` and `endpoint` is provided, the `provider` will be used for connection.

--- a/packages/api/tsconfig.build.cjs.json
+++ b/packages/api/tsconfig.build.cjs.json
@@ -23,6 +23,9 @@
     },
     {
       "path": "../storage/tsconfig.json"
+    },
+    {
+      "path": "../providers/tsconfig.json"
     }
   ]
 }

--- a/packages/api/tsconfig.build.json
+++ b/packages/api/tsconfig.build.json
@@ -19,6 +19,9 @@
     },
     {
       "path": "../storage/tsconfig.json"
+    },
+    {
+      "path": "../providers/tsconfig.json"
     }
   ]
 }

--- a/packages/api/tsconfig.json
+++ b/packages/api/tsconfig.json
@@ -26,5 +26,8 @@
     {
       "path": "../storage/tsconfig.json",
     },
+    {
+      "path": "../providers/tsconfig.json",
+    },
   ],
 }

--- a/packages/providers/LICENSE
+++ b/packages/providers/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/providers/README.md
+++ b/packages/providers/README.md
@@ -1,0 +1,5 @@
+# @dedot/providers
+
+JSON-RPC Providers
+
+ 

--- a/packages/providers/package.json
+++ b/packages/providers/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@dedot/providers",
+  "version": "0.0.1-alpha.29",
+  "description": "JSON-RPC Providers",
+  "author": "Thang X. Vu <thang@coongcrafts.io>",
+  "main": "src/index.ts",
+  "sideEffects": false,
+  "type": "module",
+  "scripts": {
+    "build": "tsc --project tsconfig.build.json && tsc --project tsconfig.build.cjs.json",
+    "clean": "rm -rf ./dist && rm -rf ./tsconfig.tsbuildinfo ./tsconfig.build.tsbuildinfo"
+  },
+  "dependencies": {
+    "@dedot/utils": "workspace:*",
+    "@polkadot/x-ws": "^12.6.2"
+  },
+  "publishConfig": {
+    "access": "public",
+    "directory": "dist"
+  },
+  "license": "Apache-2.0"
+}

--- a/packages/providers/package.json
+++ b/packages/providers/package.json
@@ -8,7 +8,8 @@
   "type": "module",
   "scripts": {
     "build": "tsc --project tsconfig.build.json && tsc --project tsconfig.build.cjs.json",
-    "clean": "rm -rf ./dist && rm -rf ./tsconfig.tsbuildinfo ./tsconfig.build.tsbuildinfo"
+    "clean": "rm -rf ./dist && rm -rf ./tsconfig.tsbuildinfo ./tsconfig.build.tsbuildinfo",
+    "test": "vitest --watch=false"
   },
   "dependencies": {
     "@dedot/utils": "workspace:*",
@@ -18,5 +19,8 @@
     "access": "public",
     "directory": "dist"
   },
-  "license": "Apache-2.0"
+  "license": "Apache-2.0",
+  "devDependencies": {
+    "mock-socket": "^9.3.1"
+  }
 }

--- a/packages/providers/src/WsProvider.ts
+++ b/packages/providers/src/WsProvider.ts
@@ -19,24 +19,24 @@ export interface WsProviderOptions {
   timeout?: number;
 }
 
-const DEFAULT_OPTIONS: Partial<WsProviderOptions> = {
+export const DEFAULT_OPTIONS: Partial<WsProviderOptions> = {
   retryDelayMs: 2_5000,
   timeout: 60_000,
 };
 
-type SubscriptionHandler = {
+export type SubscriptionHandler = {
   input: SubscriptionInput;
   callback: SubscriptionCallback;
 };
 
-interface WsRequestState {
+export interface WsRequestState {
   resolve: (value: any) => void;
   reject: (error: Error) => void;
   request: JsonRpcRequest;
   subscription?: SubscriptionHandler;
 }
 
-interface SubscriptionState {
+export interface SubscriptionState {
   input: SubscriptionInput;
   callback: SubscriptionCallback;
   subscription: Subscription;

--- a/packages/providers/src/WsProvider.ts
+++ b/packages/providers/src/WsProvider.ts
@@ -1,0 +1,277 @@
+import {
+  ConnectionStatus,
+  JsonRpcProvider,
+  JsonRpcRequest,
+  JsonRpcRequestId,
+  JsonRpcResponse,
+  JsonRpcResponseNotification,
+  ProviderEvent,
+  Subscription,
+  SubscriptionCallback,
+  SubscriptionInput,
+} from './types';
+import { assert, EventEmitter } from '@dedot/utils';
+import { WebSocket } from '@polkadot/x-ws';
+
+export interface WsProviderOptions {
+  endpoint: string;
+  retryDelayMs?: number;
+  timeout?: number;
+}
+
+const DEFAULT_OPTIONS: Partial<WsProviderOptions> = {
+  retryDelayMs: 2_5000,
+  timeout: 60_000,
+};
+
+type SubscriptionHandler = {
+  input: SubscriptionInput;
+  callback: SubscriptionCallback;
+};
+
+interface WsRequestState {
+  resolve: (value: any) => void;
+  reject: (error: Error) => void;
+  request: JsonRpcRequest;
+  subscription?: SubscriptionHandler;
+}
+
+interface SubscriptionState {
+  input: SubscriptionInput;
+  callback: SubscriptionCallback;
+  subscription: Subscription;
+}
+
+export class WsProvider extends EventEmitter<ProviderEvent> implements JsonRpcProvider {
+  #status: ConnectionStatus;
+  #options: Required<WsProviderOptions>;
+  #handlers: Record<JsonRpcRequestId, WsRequestState>;
+  #subscriptions: Record<string, SubscriptionState>;
+  #pendingNotifications: Record<string, JsonRpcResponseNotification>;
+  #ws?: WebSocket;
+  #ready: Promise<void>;
+
+  constructor(options: WsProviderOptions | string) {
+    super();
+
+    this.#status = 'disconnected';
+    this.#options = this.#normalizeOptions(options);
+    this.#handlers = {};
+    this.#subscriptions = {};
+    this.#pendingNotifications = {};
+
+    this.#ready = new Promise((resolve) => {
+      this.once('connected', resolve);
+    });
+
+    this.#connectAndRetry();
+  }
+
+  untilReady(): Promise<void> {
+    return this.#ready;
+  }
+
+  #connect() {
+    try {
+      this.#ws = new WebSocket(this.#options.endpoint);
+      this.#ws.onopen = this.#onSocketOpen;
+      this.#ws.onclose = this.#onSocketClose;
+      this.#ws.onmessage = this.#onSocketMessage;
+      this.#ws.onerror = this.#onSocketError;
+    } catch (e: any) {
+      console.error('Error connecting to websocket', e);
+      this.emit('error', e);
+      throw e;
+    }
+  }
+
+  #connectAndRetry() {
+    try {
+      this.#connect();
+    } catch (e) {
+      this.#retry();
+    }
+  }
+
+  #retry() {
+    if (this.#options.retryDelayMs <= 0) return;
+
+    setTimeout(() => {
+      this.#status = 'reconnecting';
+      this.emit('reconnecting');
+
+      this.#connectAndRetry();
+    }, this.#options.retryDelayMs);
+  }
+
+  #onSocketOpen = (event: Event) => {
+    // TODO resubcribe to previous subscriptions if this is a reconnect
+
+    this.#status = 'connected';
+    this.emit('connected');
+  };
+
+  #onSocketClose = (event: CloseEvent) => {
+    if (this.#ws) {
+      this.#ws.onclose = null;
+      this.#ws.onerror = null;
+      this.#ws.onmessage = null;
+      this.#ws.onopen = null;
+      this.#ws = undefined;
+    }
+
+    this.#status = 'disconnected';
+    this.emit('disconnected');
+
+    // TODO retry connect
+    this.#retry();
+  };
+
+  #onSocketError = (error: Event) => {
+    this.emit('error', error);
+  };
+
+  #onSocketMessage = (message: MessageEvent<string>) => {
+    const data = JSON.parse(message.data) as any;
+    const isNotification = !data.id && data.method;
+
+    if (isNotification) {
+      this.#handleNotification(data);
+    } else {
+      this.#handleResponse(data);
+    }
+  };
+
+  #handleResponse(response: JsonRpcResponse) {
+    const { id, error, result } = response;
+    const handler = this.#handlers[id];
+    const { resolve, reject } = handler;
+
+    if (error) {
+      reject(new Error(`${error.code}: ${error.message}`));
+    } else {
+      resolve(result);
+    }
+
+    delete this.#handlers[id];
+  }
+
+  #handleNotification(response: JsonRpcResponseNotification) {
+    const { method: subname, params } = response;
+    const { subscription: subscriptionId, result, error } = params;
+
+    const subkey = `${subname}::${subscriptionId}`;
+    const substate = this.#subscriptions[subkey];
+    if (!substate) {
+      this.#pendingNotifications[subkey] = response;
+      return;
+    }
+
+    const { callback } = substate;
+
+    if (error) {
+      callback(new Error(`${error.code}: ${error.message}`), null, substate.subscription);
+    } else {
+      callback(null, result, substate.subscription);
+    }
+  }
+
+  #normalizeOptions(options: WsProviderOptions | string): Required<WsProviderOptions> {
+    const normalizedOptions =
+      typeof options === 'string'
+        ? {
+            ...DEFAULT_OPTIONS,
+            endpoint: options,
+          }
+        : {
+            ...DEFAULT_OPTIONS,
+            ...options,
+          };
+
+    const { endpoint = '' } = normalizedOptions;
+
+    if (!endpoint.startsWith('ws://') && !endpoint.startsWith('wss://')) {
+      throw new Error(`Invalid websocket endpoint ${endpoint}, a valid endpoint should start with wss:// or ws://`);
+    }
+
+    return normalizedOptions as Required<WsProviderOptions>;
+  }
+
+  get status(): ConnectionStatus {
+    return this.#status;
+  }
+
+  async disconnect(): Promise<void> {
+    try {
+      this.#ws?.close(1000);
+    } catch (error: any) {
+      console.error('Error disconnecting from websocket', error);
+      this.emit('error', error);
+
+      throw error;
+    }
+  }
+
+  async send<T = any>(method: string, params: any[]): Promise<T> {
+    return new Promise((resolve, reject) => {
+      try {
+        assert(this.#ws && this.#status === 'connected', 'Websocket connection is not connected');
+
+        const [id, request] = this.#prepareRequest(method, params);
+        this.#handlers[id] = {
+          resolve,
+          reject,
+          request,
+        };
+
+        this.#ws.send(JSON.stringify(request));
+      } catch (e) {
+        reject(e);
+      }
+    });
+  }
+
+  async subscribe<T = any>(input: SubscriptionInput, callback: SubscriptionCallback<T>): Promise<Subscription> {
+    const { subname, subscribe, params, unsubscribe } = input;
+    const subscriptionId = await this.send<string>(subscribe, params);
+
+    const subkey = `${subname}::${subscriptionId}`;
+
+    const subscription: Subscription = {
+      unsubscribe: async () => {
+        delete this.#subscriptions[subkey];
+        await this.send(unsubscribe, [subscriptionId]);
+      },
+      subscriptionId,
+    };
+
+    this.#subscriptions[subkey] = {
+      input,
+      callback,
+      subscription,
+    };
+
+    // Handle pending notifications
+    if (this.#pendingNotifications[subkey]) {
+      this.#handleNotification(this.#pendingNotifications[subkey]);
+      delete this.#pendingNotifications[subkey];
+    }
+
+    return subscription;
+  }
+
+  #id: JsonRpcRequestId = 0;
+  #prepareRequest(method: string, params: any[]): [JsonRpcRequestId, JsonRpcRequest] {
+    const id = ++this.#id;
+
+    return [
+      id,
+      {
+        id,
+        jsonrpc: '2.0',
+        method,
+        params,
+      },
+    ];
+  }
+}

--- a/packages/providers/src/index.ts
+++ b/packages/providers/src/index.ts
@@ -1,0 +1,2 @@
+export * from './types';
+export * from './WsProvider';

--- a/packages/providers/src/index.ts
+++ b/packages/providers/src/index.ts
@@ -1,2 +1,2 @@
-export * from './types';
-export * from './WsProvider';
+export * from './types.js';
+export * from './ws/index.js';

--- a/packages/providers/src/json-rpc.ts
+++ b/packages/providers/src/json-rpc.ts
@@ -1,0 +1,33 @@
+export type JsonRpcRequestId = number;
+export interface JsonRpcV2 {
+  id: JsonRpcRequestId;
+  jsonrpc: '2.0';
+}
+
+export interface JsonRpcRequest extends JsonRpcV2 {
+  method: string;
+  params: unknown[];
+}
+
+export interface JsonRpcResponseError<D = any> {
+  error?: {
+    code: number;
+    message: string;
+    data?: D;
+  };
+}
+
+export interface JsonRpcResponseSuccess<T = any> {
+  result?: T;
+}
+
+export interface JsonRpcResponseNotification<T = any> {
+  jsonrpc: '2.0';
+  method: string;
+  params: {
+    subscription: number | string;
+    result?: T;
+  } & JsonRpcResponseError;
+}
+
+export type JsonRpcResponse<T = any> = JsonRpcV2 & JsonRpcResponseSuccess<T> & JsonRpcResponseError;

--- a/packages/providers/src/json-rpc.ts
+++ b/packages/providers/src/json-rpc.ts
@@ -1,3 +1,6 @@
+// JSON-RPC v2 types
+// Specs: https://www.jsonrpc.org/specification
+
 export type JsonRpcRequestId = number;
 export interface JsonRpcV2 {
   id: JsonRpcRequestId;
@@ -21,6 +24,7 @@ export interface JsonRpcResponseSuccess<T = any> {
   result?: T;
 }
 
+// https://www.jsonrpc.org/specification#notification
 export interface JsonRpcResponseNotification<T = any> {
   jsonrpc: '2.0';
   method: string;

--- a/packages/providers/src/types.ts
+++ b/packages/providers/src/types.ts
@@ -28,7 +28,7 @@ export type SubscriptionInput = {
 };
 
 export type ConnectionStatus = 'connected' | 'disconnected' | 'reconnecting';
-export type ProviderEvent = ConnectionStatus | 'error';
+export type ProviderEvent = ConnectionStatus | 'error'; // | 'timeout';
 
 export interface JsonRpcProvider extends IEventEmitter<ProviderEvent> {
   /**
@@ -57,7 +57,7 @@ export interface JsonRpcProvider extends IEventEmitter<ProviderEvent> {
   /**
    * Connect to the provider
    */
-  connect(): Promise<void>;
+  connect(): Promise<this>;
 
   /**
    * Disconnect from the provider

--- a/packages/providers/src/types.ts
+++ b/packages/providers/src/types.ts
@@ -1,0 +1,26 @@
+import { EventEmitter } from '@dedot/utils';
+
+export * from './json-rpc';
+
+export type Subscription = {
+  unsubscribe: () => Promise<void>;
+  subscriptionId: string;
+};
+
+export type SubscriptionCallback<T = any> = (error: Error | null, result: T | null, subscription: Subscription) => void;
+export type SubscriptionInput = {
+  subname: string;
+  subscribe: string;
+  params: any[];
+  unsubscribe: string;
+};
+
+export type ConnectionStatus = 'connected' | 'disconnected' | 'reconnecting';
+export type ProviderEvent = ConnectionStatus | 'error';
+
+export interface JsonRpcProvider extends EventEmitter<ProviderEvent> {
+  status: ConnectionStatus;
+  send<T = any>(method: string, params: any[]): Promise<T>;
+  subscribe<T = any>(input: SubscriptionInput, callback: SubscriptionCallback<T>): Promise<Subscription>;
+  disconnect(): Promise<void>;
+}

--- a/packages/providers/src/types.ts
+++ b/packages/providers/src/types.ts
@@ -1,6 +1,6 @@
 import type { IEventEmitter } from '@dedot/utils';
 
-export * from './json-rpc';
+export * from './json-rpc.js';
 
 export type Subscription = {
   unsubscribe: () => Promise<void>;
@@ -9,9 +9,21 @@ export type Subscription = {
 
 export type SubscriptionCallback<T = any> = (error: Error | null, result: T | null, subscription: Subscription) => void;
 export type SubscriptionInput = {
+  /**
+   * Subscription name, this value should be present in the notification response from the server/node
+   */
   subname: string;
+  /**
+   * Subscribe method
+   */
   subscribe: string;
+  /**
+   * Subscribe parameters
+   */
   params: any[];
+  /**
+   * Unsubscribe method
+   */
   unsubscribe: string;
 };
 
@@ -19,9 +31,36 @@ export type ConnectionStatus = 'connected' | 'disconnected' | 'reconnecting';
 export type ProviderEvent = ConnectionStatus | 'error';
 
 export interface JsonRpcProvider extends IEventEmitter<ProviderEvent> {
+  /**
+   * The current connection status
+   */
   status: ConnectionStatus;
+
+  /**
+   * Send a JSON-RPC request,
+   * make sure to connect to the provider first before sending requests
+   *
+   * @param method
+   * @param params
+   */
   send<T = any>(method: string, params: any[]): Promise<T>;
+
+  /**
+   * Make a subscription request,
+   * make sure to connect to the provider first before sending requests
+   *
+   * @param input
+   * @param callback
+   */
   subscribe<T = any>(input: SubscriptionInput, callback: SubscriptionCallback<T>): Promise<Subscription>;
+
+  /**
+   * Connect to the provider
+   */
   connect(): Promise<void>;
+
+  /**
+   * Disconnect from the provider
+   */
   disconnect(): Promise<void>;
 }

--- a/packages/providers/src/types.ts
+++ b/packages/providers/src/types.ts
@@ -1,4 +1,4 @@
-import { EventEmitter } from '@dedot/utils';
+import type { IEventEmitter } from '@dedot/utils';
 
 export * from './json-rpc';
 
@@ -18,7 +18,7 @@ export type SubscriptionInput = {
 export type ConnectionStatus = 'connected' | 'disconnected' | 'reconnecting';
 export type ProviderEvent = ConnectionStatus | 'error';
 
-export interface JsonRpcProvider extends EventEmitter<ProviderEvent> {
+export interface JsonRpcProvider extends IEventEmitter<ProviderEvent> {
   status: ConnectionStatus;
   send<T = any>(method: string, params: any[]): Promise<T>;
   subscribe<T = any>(input: SubscriptionInput, callback: SubscriptionCallback<T>): Promise<Subscription>;

--- a/packages/providers/src/types.ts
+++ b/packages/providers/src/types.ts
@@ -22,5 +22,6 @@ export interface JsonRpcProvider extends IEventEmitter<ProviderEvent> {
   status: ConnectionStatus;
   send<T = any>(method: string, params: any[]): Promise<T>;
   subscribe<T = any>(input: SubscriptionInput, callback: SubscriptionCallback<T>): Promise<Subscription>;
+  connect(): Promise<void>;
   disconnect(): Promise<void>;
 }

--- a/packages/providers/src/ws/WsProvider.ts
+++ b/packages/providers/src/ws/WsProvider.ts
@@ -191,6 +191,7 @@ export class WsProvider extends EventEmitter<ProviderEvent> implements JsonRpcPr
     this.#handlers = {};
     this.#subscriptions = {};
     this.#pendingNotifications = {};
+    this.clearEvents();
   }
 
   #onSocketClose = (event: CloseEvent) => {

--- a/packages/providers/src/ws/__tests__/WsProvider.spec.ts
+++ b/packages/providers/src/ws/__tests__/WsProvider.spec.ts
@@ -1,0 +1,108 @@
+import { WsProvider } from '../WsProvider.js';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { Client, Server } from 'mock-socket';
+import { JsonRpcRequest, JsonRpcResponse } from '@dedot/providers';
+
+const FAKE_WS_URL = 'ws://127.0.0.1:9944';
+
+vi.mock('@polkadot/x-ws', async (importOriginal) => {
+  const { WebSocket } = await import('mock-socket');
+  const mod = await importOriginal<typeof import('@polkadot/x-ws')>();
+  return {
+    ...mod,
+    WebSocket,
+  };
+});
+
+describe('WsProvider', () => {
+  let mockServer: Server;
+
+  beforeAll(() => {
+    const sendResponse = (socket: Client, message: JsonRpcRequest) => {
+      socket.send(JSON.stringify({ id: message.id, jsonrpc: '2.0', result: 'ok' } as JsonRpcResponse<string>));
+    };
+
+    mockServer = new Server(FAKE_WS_URL);
+
+    mockServer.on('connection', (socket) => {
+      socket.on('message', (data) => {
+        const message: JsonRpcRequest = JSON.parse(data.toString());
+        if (message.method === 'delayed_method') {
+          setTimeout(() => {
+            sendResponse(socket, message);
+          }, 60_000);
+        } else {
+          sendResponse(socket, message);
+        }
+      });
+    });
+  });
+
+  afterAll(() => {
+    mockServer.stop();
+  });
+
+  it('connects to a valid websocket endpoint', async () => {
+    const provider = new WsProvider(FAKE_WS_URL);
+    await expect(provider.connect()).resolves.toBe(provider);
+  });
+
+  it('throws an error when connecting to an invalid websocket endpoint', async () => {
+    const provider = new WsProvider({ endpoint: 'ws://localhost:1234', retryDelayMs: -1 });
+    await expect(provider.connect()).rejects.toThrow();
+  });
+
+  it('sends a JSON-RPC request over the websocket connection', async () => {
+    const provider = new WsProvider(FAKE_WS_URL);
+    await provider.connect();
+    await expect(provider.send('method', ['param1', 'param2'])).resolves.toEqual('ok');
+  });
+
+  it('subscribes to a JSON-RPC method over the websocket connection', async () => {
+    const provider = new WsProvider(FAKE_WS_URL);
+    await provider.connect();
+    const subscription = await provider.subscribe(
+      { subname: 'subname', subscribe: 'subscribe_method', params: [], unsubscribe: 'unsubscribe_method' },
+      () => {},
+    );
+    expect(subscription).toBeDefined();
+  });
+
+  it('unsubscribes from a JSON-RPC method over the websocket connection', async () => {
+    const provider = new WsProvider(FAKE_WS_URL);
+    await provider.connect();
+    const subscription = await provider.subscribe(
+      { subname: 'subname', subscribe: 'subscribe_method', params: [], unsubscribe: 'unsubscribe_method' },
+      () => {},
+    );
+    await expect(subscription.unsubscribe()).resolves.toBeUndefined();
+  });
+
+  it('disconnects from the websocket endpoint', async () => {
+    const provider = new WsProvider(FAKE_WS_URL);
+    await provider.connect();
+    await expect(provider.disconnect()).resolves.toBeUndefined();
+  });
+
+  it('throws an error when the request is timed out', () =>
+    new Promise<void>(async (resolve, reject) => {
+      vi.useFakeTimers();
+
+      const provider = new WsProvider({ endpoint: FAKE_WS_URL, timeout: 10_000 });
+
+      provider.connect().then(() => {
+        provider
+          .send('delayed_method', [])
+          .then(reject)
+          .catch((error: Error) => {
+            error.message === 'Request timed out after 10000ms' ? resolve() : reject();
+          });
+
+        vi.advanceTimersByTime(20_000);
+      });
+
+      // Advance the timers to resolve the provider connection
+      // before start sending test requests
+      vi.advanceTimersByTime(1000);
+    }));
+});

--- a/packages/providers/src/ws/index.ts
+++ b/packages/providers/src/ws/index.ts
@@ -1,0 +1,1 @@
+export * from './WsProvider.js';

--- a/packages/providers/tsconfig.build.cjs.json
+++ b/packages/providers/tsconfig.build.cjs.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.build.json",
+  "compilerOptions": {
+    "outDir": "dist/cjs",
+    "module": "CommonJS"
+  },
+  "exclude": ["**/__tests__/*"],
+  "references": [
+    {
+      "path": "../utils/tsconfig.json"
+    }
+  ]
+}

--- a/packages/providers/tsconfig.build.json
+++ b/packages/providers/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["**/__tests__/*"],
+  "references": [
+    {
+      "path": "../utils/tsconfig.json"
+    }
+  ]
+}

--- a/packages/providers/tsconfig.json
+++ b/packages/providers/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "baseUrl": "./",
+    "outDir": "dist",
+    "rootDir": "src",
+    "declarationDir": "dist",
+  },
+  "include": ["src/**/*"],
+  "references": [
+    {
+      "path": "../utils/tsconfig.json",
+    },
+  ],
+}

--- a/packages/types/src/types/index.ts
+++ b/packages/types/src/types/index.ts
@@ -17,7 +17,7 @@ export * from './event.js';
 export type Append<T extends readonly unknown[], V> = [...T, V];
 export type AnyFunc = (...args: any[]) => any;
 export type AsyncMethod = (...args: any[]) => Promise<any>;
-export type Unsub = () => Promise<boolean>;
+export type Unsub = () => Promise<void>;
 export type Callback<T> = (result: T) => Promise<void> | void;
 
 export interface GenericPalletError {

--- a/packages/utils/src/event/EventEmitter.ts
+++ b/packages/utils/src/event/EventEmitter.ts
@@ -19,6 +19,10 @@ export class EventEmitter<EventTypes extends string = string> implements IEventE
     return this.#emitter.emit(event, ...args);
   }
 
+  protected clearEvents() {
+    this.#emitter.removeAllListeners();
+  }
+
   public on(event: EventTypes, handler: HandlerFn): this {
     this.#emitter.on(event, handler);
 

--- a/packages/utils/src/event/EventEmitter.ts
+++ b/packages/utils/src/event/EventEmitter.ts
@@ -2,7 +2,13 @@ import { EventEmitter as EE } from 'eventemitter3';
 
 type HandlerFn = (...args: any[]) => void;
 
-export class EventEmitter<EventTypes extends string = string> {
+export interface IEventEmitter<EventTypes extends string = string> {
+  on(event: EventTypes, handler: HandlerFn): this;
+  once(event: EventTypes, handler: HandlerFn): this;
+  off(event: EventTypes, handler?: HandlerFn): this;
+}
+
+export class EventEmitter<EventTypes extends string = string> implements IEventEmitter<EventTypes> {
   #emitter: EE;
 
   constructor() {

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -36,6 +36,8 @@
       "@dedot/utils/*": ["../utils/src/*"],
       "@dedot/storage": ["../storage/src"],
       "@dedot/storage/*": ["../storage/src/*"],
+      "@dedot/providers": ["../providers/src"],
+      "@dedot/providers/*": ["../providers/src/*"],
       "dedot": ["../api/src"],
       "dedot/*": ["../api/src/*"]
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -407,6 +407,7 @@ __metadata:
   dependencies:
     "@dedot/utils": "workspace:*"
     "@polkadot/x-ws": "npm:^12.6.2"
+    mock-socket: "npm:^9.3.1"
   languageName: unknown
   linkType: soft
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -401,6 +401,15 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@dedot/providers@workspace:^, @dedot/providers@workspace:packages/providers":
+  version: 0.0.0-use.local
+  resolution: "@dedot/providers@workspace:packages/providers"
+  dependencies:
+    "@dedot/utils": "workspace:*"
+    "@polkadot/x-ws": "npm:^12.6.2"
+  languageName: unknown
+  linkType: soft
+
 "@dedot/shape@npm:0.0.1-next.70fc26c6.11+70fc26c":
   version: 0.0.1-next.70fc26c6.11
   resolution: "@dedot/shape@npm:0.0.1-next.70fc26c6.11"
@@ -3465,6 +3474,7 @@ __metadata:
   dependencies:
     "@dedot/chaintypes": "npm:0.0.1-alpha.35"
     "@dedot/codecs": "workspace:*"
+    "@dedot/providers": "workspace:^"
     "@dedot/shape": "workspace:*"
     "@dedot/specs": "workspace:*"
     "@dedot/storage": "workspace:*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -401,7 +401,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@dedot/providers@workspace:^, @dedot/providers@workspace:packages/providers":
+"@dedot/providers@workspace:*, @dedot/providers@workspace:^, @dedot/providers@workspace:packages/providers":
   version: 0.0.0-use.local
   resolution: "@dedot/providers@workspace:packages/providers"
   dependencies:
@@ -9339,6 +9339,7 @@ __metadata:
   dependencies:
     "@dedot/chaintypes": "npm:0.0.1-alpha.35"
     "@dedot/codecs": "workspace:*"
+    "@dedot/providers": "workspace:*"
     "@dedot/utils": "workspace:*"
     "@polkadot/keyring": "npm:^12.6.2"
     dedot: "workspace:*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1430,7 +1430,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/rpc-provider@npm:10.11.2, @polkadot/rpc-provider@npm:^10.11.2":
+"@polkadot/rpc-provider@npm:10.11.2":
   version: 10.11.2
   resolution: "@polkadot/rpc-provider@npm:10.11.2"
   dependencies:
@@ -3480,7 +3480,6 @@ __metadata:
     "@dedot/storage": "workspace:*"
     "@dedot/utils": "workspace:*"
     "@polkadot/keyring": "npm:^12.6.2"
-    "@polkadot/rpc-provider": "npm:^10.11.2"
     "@polkadot/types": "npm:^10.11.2"
   languageName: unknown
   linkType: soft

--- a/zombienet-tests/package.json
+++ b/zombienet-tests/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "@dedot/chaintypes": "0.0.1-alpha.35",
     "@dedot/codecs": "workspace:*",
+    "@dedot/providers": "workspace:*",
     "@dedot/utils": "workspace:*",
     "@polkadot/keyring": "^12.6.2",
     "dedot": "workspace:*"

--- a/zombienet-tests/src/0001-check-ws-provider-connection.ts
+++ b/zombienet-tests/src/0001-check-ws-provider-connection.ts
@@ -1,5 +1,5 @@
 import { WsProvider } from '@dedot/providers';
-import { assert } from '@dedot/utils';
+import { assert, isHex, isNumber } from '@dedot/utils';
 
 export const run = async (nodeName: any, networkInfo: any): Promise<void> => {
   const { wsUri: endpoint } = networkInfo.nodesByName[nodeName];
@@ -9,7 +9,7 @@ export const run = async (nodeName: any, networkInfo: any): Promise<void> => {
   await provider.untilReady();
 
   const hash = await provider.send('chain_getBlockHash', [0]);
-  assert(typeof hash === 'string', 'Expected a string value');
+  assert(isHex(hash), 'Expected a string value');
   console.log('genesis hash', hash);
 
   await provider.disconnect();
@@ -34,6 +34,9 @@ export const run = async (nodeName: any, networkInfo: any): Promise<void> => {
           reject(error);
         } else {
           console.log('New head', head);
+          assert(isHex(head.parentHash), 'Expected a string value');
+          assert(isNumber(parseInt(head.number, 16)), 'Expected a number value');
+
           resolve();
         }
       },

--- a/zombienet-tests/src/0001-check-ws-provider-connection.ts
+++ b/zombienet-tests/src/0001-check-ws-provider-connection.ts
@@ -1,0 +1,42 @@
+import { WsProvider } from '@dedot/providers';
+import { assert } from '@dedot/utils';
+
+export const run = async (nodeName: any, networkInfo: any): Promise<void> => {
+  const { wsUri: endpoint } = networkInfo.nodesByName[nodeName];
+
+  const provider = new WsProvider(endpoint);
+
+  await provider.untilReady();
+
+  const hash = await provider.send('chain_getBlockHash', [0]);
+  assert(typeof hash === 'string', 'Expected a string value');
+  console.log('genesis hash', hash);
+
+  await provider.disconnect();
+
+  await provider.connect();
+
+  return new Promise(async (resolve, reject) => {
+    const subscription = await provider.subscribe(
+      {
+        subname: 'chain_newHead',
+        subscribe: 'chain_subscribeNewHead',
+        unsubscribe: 'chain_unsubscribeNewHead',
+        params: [],
+      },
+      async (error, head, subscriptionObject) => {
+        await subscriptionObject.unsubscribe();
+
+        assert(subscription === subscriptionObject, 'Subscription object mismatch');
+
+        if (error) {
+          console.error('Error in newHead subscription', error);
+          reject(error);
+        } else {
+          console.log('New head', head);
+          resolve();
+        }
+      },
+    );
+  });
+};

--- a/zombienet-tests/src/0001-check-ws-provider-connection.ts
+++ b/zombienet-tests/src/0001-check-ws-provider-connection.ts
@@ -6,6 +6,13 @@ export const run = async (nodeName: any, networkInfo: any): Promise<void> => {
 
   const provider = new WsProvider(endpoint);
 
+  try {
+    await provider.send('chain_getBlockHash', [0]);
+    throw new Error('Expected an error here!');
+  } catch (e: any) {
+    assert(e.message === 'Websocket connection is not connected');
+  }
+
   await provider.untilReady();
 
   const hash = await provider.send('chain_getBlockHash', [0]);

--- a/zombienet-tests/src/0001-check-ws-provider-connection.ts
+++ b/zombienet-tests/src/0001-check-ws-provider-connection.ts
@@ -13,7 +13,7 @@ export const run = async (nodeName: any, networkInfo: any): Promise<void> => {
     assert(e.message === 'Websocket connection is not connected');
   }
 
-  await provider.untilReady();
+  await provider.connect();
 
   const hash = await provider.send('chain_getBlockHash', [0]);
   assert(isHex(hash), 'Expected a string value');

--- a/zombienet-tests/src/0001-small-network.zndsl
+++ b/zombienet-tests/src/0001-small-network.zndsl
@@ -5,7 +5,8 @@ Creds: config
 alice: is up
 bob: is up
 alice: reports node_roles is 4
-alice: ts-script ./0001-check-runtime-api.ts within 200 seconds
-alice: ts-script ./0001-check-storage-query.ts within 200 seconds
-alice: ts-script ./0001-check-tx-transfer-balance.ts within 200 seconds
-alice: ts-script ./0001-check-tx-batch.ts within 200 seconds
+alice: ts-script ./0001-check-runtime-api.ts within 100 seconds
+alice: ts-script ./0001-check-storage-query.ts within 100 seconds
+alice: ts-script ./0001-check-tx-transfer-balance.ts within 100 seconds
+alice: ts-script ./0001-check-tx-batch.ts within 100 seconds
+alice: ts-script ./0001-check-ws-provider-connection.ts within 100 seconds

--- a/zombienet-tests/tsconfig.json
+++ b/zombienet-tests/tsconfig.json
@@ -10,6 +10,8 @@
       "@dedot/codecs/*": ["../packages/codecs/src/*"],
       "@dedot/utils": ["../packages/utils/src"],
       "@dedot/utils/*": ["../packages/utils/src/*"],
+      "@dedot/providers": ["../packages/providers/src"],
+      "@dedot/providers/*": ["../packages/providers/src/*"],
       "dedot": ["../packages/api/src"],
       "dedot/*": ["../packages/api/src/*"],
     },
@@ -21,6 +23,9 @@
     },
     {
       "path": "../packages/codecs/tsconfig.json",
+    },
+    {
+      "path": "../packages/providers/tsconfig.json",
     },
     {
       "path": "../packages/api/tsconfig.json",


### PR DESCRIPTION
This resolves the last piece of #47 which is to help us move away from `@polkadot/rpc-provider` thus completely remove the dependency on `bn.js`

This PR is likely to introduce some breaking changes!