### PR TITLE
fix: mismatch order of query subscription changes

### DIFF
--- a/packages/api/src/executor/StorageQueryExecutor.ts
+++ b/packages/api/src/executor/StorageQueryExecutor.ts
@@ -41,10 +41,9 @@ export class StorageQueryExecutor<ChainApi extends GenericSubstrateApi = Substra
 
       // if a callback is passed, make a storage subscription and return an unsub function
       if (callback) {
-        return await this.subscribeStorage([encodedKey], (changeSet: StorageChangeSet) => {
-          const targetChange = changeSet.changes.find((change) => change[0] === encodedKey);
-
-          targetChange && callback(entry.decodeValue(targetChange[1]));
+        return await this.subscribeStorage([encodedKey], (changes: Array<StorageData | undefined>) => {
+          if (changes.length === 0) return;
+          callback(entry.decodeValue(changes[0]));
         });
       } else {
         return getStorage(encodedKey);
@@ -59,10 +58,8 @@ export class StorageQueryExecutor<ChainApi extends GenericSubstrateApi = Substra
 
       // if a callback is passed, make a storage subscription and return an unsub function
       if (callback) {
-        return await this.subscribeStorage(encodedKeys, (changeSet: StorageChangeSet) => {
-          const targetChanges = changeSet.changes.filter((change) => encodedKeys.includes(change[0]));
-
-          callback(targetChanges.map((change) => entry.decodeValue(change[1])));
+        return await this.subscribeStorage(encodedKeys, (changes: Array<StorageData | undefined>) => {
+          callback(changes.map((change) => entry.decodeValue(change)));
         });
       } else {
         return await Promise.all(encodedKeys.map(getStorage));
@@ -119,7 +116,17 @@ export class StorageQueryExecutor<ChainApi extends GenericSubstrateApi = Substra
     return this.api.rpc.state_getStorage(key, at);
   }
 
-  protected subscribeStorage(keys: StorageKey[], callback: Callback<StorageChangeSet>): Promise<Unsub> {
-    return this.api.rpc.state_subscribeStorage(keys, callback);
+  protected subscribeStorage(keys: StorageKey[], callback: Callback<Array<StorageData | undefined>>): Promise<Unsub> {
+    const lastChanges = {} as Record<StorageKey, StorageData | undefined>;
+
+    return this.api.rpc.state_subscribeStorage(keys, (changeSet: StorageChangeSet) => {
+      changeSet.changes.forEach(([key, value]) => {
+        if (lastChanges[key] !== value) {
+          lastChanges[key] = value ?? undefined;
+        }
+      });
+
+      return callback(keys.map((key) => lastChanges[key]));
+    });
   }
 }


### PR DESCRIPTION
As title, this happens because the storage subscription only notify the changed storage values.