### PR TITLE
feat(api): update api exposure

### DIFF
--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -1,8 +1,8 @@
 export type * from './types.js';
-export type * from './chaintypes/index.js';
 
-export * from './executor/index.js';
+export * from './storage/index.js';
 export * from './extrinsic/index.js';
+export * from './executor/index.js';
 
 export * from './json-rpc/index.js';
 export { Dedot } from './client/index.js';

--- a/packages/api/src/storage/index.ts
+++ b/packages/api/src/storage/index.ts
@@ -1,0 +1,1 @@
+export * from './QueryableStorage.js';

--- a/scripts/copy-files-to-dist.js
+++ b/scripts/copy-files-to-dist.js
@@ -39,23 +39,21 @@ const main = () => {
       if (!['@dedot/cli'].includes(pkgJson.name)) {
         pkgJson.exports = {
           '.': {
-            import: {
-              types: './index.d.ts',
-              default: './index.js',
-            },
-            require: {
-              types: './index.d.ts',
-              default: './cjs/index.js',
-            },
+            types: './index.d.ts',
+            import: './index.js',
+            require: './cjs/index.js',
+            default: './index.js',
           },
         };
       }
 
+      // Export default/generic substrate chaintypes
       if (pkgJson.name === 'dedot') {
         pkgJson.exports['./chaintypes'] = {
           types: './chaintypes/index.d.ts',
           import: './chaintypes/index.js',
           require: './cjs/chaintypes/index.js',
+          default: './chaintypes/index.js',
         };
       }
 

--- a/scripts/copy-files-to-dist.js
+++ b/scripts/copy-files-to-dist.js
@@ -51,6 +51,14 @@ const main = () => {
         };
       }
 
+      if (pkgJson.name === 'dedot') {
+        pkgJson.exports['./chaintypes'] = {
+          types: './chaintypes/index.d.ts',
+          import: './chaintypes/index.js',
+          require: './cjs/chaintypes/index.js',
+        };
+      }
+
       fileContent = JSON.stringify(pkgJson, null, 2);
     }
 


### PR DESCRIPTION
Changes:
- Expose `QueryableStorage` type
- Expose default/generic substrate chaintypes under `dedot/chaintypes` instead of the root `dedot` namespace.