### PR TITLE
tweak(api): improve multi storage query

### DIFF
--- a/packages/api/src/client/__tests__/Dedot.spec.ts
+++ b/packages/api/src/client/__tests__/Dedot.spec.ts
@@ -64,6 +64,20 @@ describe('Dedot', () => {
           pallet.storage?.entries.forEach((entry) => {
             expect(api.query[stringCamelCase(pallet.name)][stringCamelCase(entry.name)]).toBeDefined();
             expect(api.query[stringCamelCase(pallet.name)][stringCamelCase(entry.name)].multi).toBeDefined();
+            expect(api.query[stringCamelCase(pallet.name)][stringCamelCase(entry.name)].meta).toBeDefined();
+            expectTypeOf(api.query[stringCamelCase(pallet.name)][stringCamelCase(entry.name)].rawKey).toBeFunction();
+
+            if (entry.type.tag === 'Map') {
+              // @ts-ignore
+              expect(api.query[stringCamelCase(pallet.name)][stringCamelCase(entry.name)].keys).toBeDefined();
+              // @ts-ignore
+              expect(api.query[stringCamelCase(pallet.name)][stringCamelCase(entry.name)].entries).toBeDefined();
+            } else {
+              // @ts-ignore
+              expect(api.query[stringCamelCase(pallet.name)][stringCamelCase(entry.name)].keys).toBeUndefined();
+              // @ts-ignore
+              expect(api.query[stringCamelCase(pallet.name)][stringCamelCase(entry.name)].entries).toBeUndefined();
+            }
           });
         });
       });
@@ -286,7 +300,7 @@ describe('Dedot', () => {
 
         const key = apiAt.query.system.number.rawKey();
         await apiAt.query.system.number();
-        expect(providerSend).toBeCalledWith('state_getStorage', [key, atHash]);
+        expect(providerSend).toBeCalledWith('state_queryStorageAt', [[key], atHash]);
 
         await apiAt.call.metadata.metadata();
         expect(providerSend).toBeCalledWith('state_call', ['Metadata_metadata', '0x', atHash]);

--- a/packages/api/src/client/__tests__/MockProvider.ts
+++ b/packages/api/src/client/__tests__/MockProvider.ts
@@ -36,6 +36,7 @@ export default class MockProvider extends EventEmitter<ProviderEvent> implements
     state_getMetadata: () => staticSubstrate,
     state_call: () => '0x',
     state_getStorage: () => '0x',
+    state_queryStorageAt: () => [{ block: '0x', changes: ['0x', '0x'] }],
   };
 
   setStatus(status: ConnectionStatus) {


### PR DESCRIPTION
We're using `state_queryStorageAt` instead of `state_getStorage` for storage query to optimize multi query.