### PR TITLE
feat(api): json rpc groups

### DIFF
--- a/packages/api/src/client/__tests__/MockProvider.ts
+++ b/packages/api/src/client/__tests__/MockProvider.ts
@@ -74,6 +74,13 @@ export default class MockProvider extends EventEmitter<ProviderEvent> implements
     this.rpcRequests[name] = response;
   }
 
+  setRpcRequests(requests: Record<string, AnyFunc>) {
+    this.rpcRequests = {
+      ...this.rpcRequests,
+      ...requests,
+    };
+  }
+
   get status(): ConnectionStatus {
     return this.#status;
   }

--- a/packages/api/src/json-rpc/group/ChainSpec.ts
+++ b/packages/api/src/json-rpc/group/ChainSpec.ts
@@ -1,0 +1,22 @@
+import { Properties } from '@dedot/specs';
+import { HexString } from '@dedot/utils';
+import { IJsonRpcClient } from '../../types.js';
+import { JsonRpcGroup, JsonRpcGroupOptions } from './JsonRpcGroup.js';
+
+export class ChainSpec extends JsonRpcGroup {
+  constructor(client: IJsonRpcClient, options?: Partial<JsonRpcGroupOptions>) {
+    super(client, { prefix: 'chainSpec', supportedVersions: ['unstable', 'v1'], ...options });
+  }
+
+  async chainName(): Promise<string> {
+    return this.send('chainName');
+  }
+
+  async genesisHash(): Promise<HexString> {
+    return this.send('genesisHash');
+  }
+
+  async properties(): Promise<Properties> {
+    return this.send('properties');
+  }
+}

--- a/packages/api/src/json-rpc/group/JsonRpcGroup.ts
+++ b/packages/api/src/json-rpc/group/JsonRpcGroup.ts
@@ -1,0 +1,135 @@
+import { RpcMethods } from '@dedot/specs';
+import { EventEmitter } from '@dedot/utils';
+import { IJsonRpcClient } from '../../types.js';
+
+export type JsonRpcGroupVersion = 'unstable' | `v${number}`;
+export interface JsonRpcGroupOptions {
+  /**
+   * Prefix of the json-rpc group.
+   * E.g: chainHead, chainSpec, archive, etc.
+   *
+   * According to JSON-RPC v2 Spec: https://paritytech.github.io/json-rpc-interface-spec/grouping-functions-and-node-capabilities.html#grouping-functions-and-node-capabilities
+   *
+   * Note: The prefix should not contain any `_` character.
+   */
+  prefix: string;
+
+  /**
+   * By default, the version is automatically detected from the available rpc-methods.
+   * If a fixed version is provided, it will be forced to use instead.
+   */
+  fixedVersion?: JsonRpcGroupVersion;
+
+  /**
+   * List of rpc-methods to use for version detection.
+   * If not provided, the list will be fetched from the node/server.
+   * This is helpful when the node does not support `rpc_methods` method
+   * Or if we want to share the same rpc-methods list across multiple groups.
+   */
+  rpcMethods?: string[];
+
+  /**
+   * List of supported versions.
+   * If provided, the detected version must be in this list else an error will be thrown.
+   * This is helpful when we want to verify behaviour of new version before using/support it.
+   * If not provided, any detected version will be used.
+   */
+  supportedVersions?: JsonRpcGroupVersion[];
+}
+
+/**
+ * @name JsonRpcGroup
+ * A group of json-rpc methods with a common prefix.
+ *
+ * JSON-RPC V2: https://paritytech.github.io/json-rpc-interface-spec/grouping-functions-and-node-capabilities.html#grouping-functions-and-node-capabilities
+ */
+export class JsonRpcGroup<Event extends string = string> extends EventEmitter<Event> {
+  #detectedVersion?: JsonRpcGroupVersion;
+
+  constructor(
+    public client: IJsonRpcClient,
+    public options: JsonRpcGroupOptions,
+  ) {
+    super();
+  }
+
+  /**
+   * Check if the group is supported by the connected JSON-RPC server.
+   */
+  async supported(): Promise<boolean> {
+    try {
+      const detectedVersion = await this.#detectVersion();
+
+      const { supportedVersions } = this.options;
+
+      // if there aren't any specific supported versions, then any detected version is supported
+      if (!supportedVersions || supportedVersions.length === 0) return true;
+
+      return supportedVersions.includes(detectedVersion);
+    } catch {}
+
+    return false;
+  }
+
+  /**
+   * Send a json-rpc request, note the method should not contain the prefix and version parts.
+   *
+   * @example
+   * ```typescript
+   * const client = await JsonRpcClient.new('wss://rpc.polkadot.io');
+   * const achieve = new JsonRpcGroup(client, { prefix: 'archive', supportedVersions: ['unstable'] });
+   *
+   * const finalizedHeight = await achieve.send<number>('finalizedHeight'); // sending archive_unstable_finalizedHeight
+   * console.log(finalizedHeight);
+   * ```
+   *
+   * @param method
+   * @param params
+   */
+  async send<T = any>(method: string, ...params: any[]): Promise<T> {
+    const rpcMethod = `${this.prefix}_${await this.version()}_${method}`;
+    return this.client.rpc[rpcMethod](...params);
+  }
+
+  /**
+   * The prefix of the group
+   */
+  get prefix(): string {
+    return this.options.prefix;
+  }
+
+  /**
+   * Detect & return the version of the group.
+   * This will be used to construct the json-rpc method name.
+   */
+  async version(): Promise<JsonRpcGroupVersion> {
+    const { fixedVersion, supportedVersions } = this.options;
+    if (fixedVersion) return fixedVersion;
+
+    const detectedVersion = await this.#detectVersion();
+    if (supportedVersions && supportedVersions.length > 0 && !supportedVersions.includes(detectedVersion)) {
+      throw new Error(`Detected version ${detectedVersion} is not supported`);
+    }
+
+    return detectedVersion;
+  }
+
+  async #detectVersion(): Promise<JsonRpcGroupVersion> {
+    if (!this.#detectedVersion) {
+      this.#detectedVersion = await this.#doDetectVersion();
+    }
+
+    return this.#detectedVersion;
+  }
+
+  async #doDetectVersion(): Promise<JsonRpcGroupVersion> {
+    const rpcMethods = this.options.rpcMethods || ((await this.client.rpc.rpc_methods()) as RpcMethods).methods;
+    const prefixedMethods = rpcMethods.filter((method) => method.startsWith(`${this.prefix}_`));
+
+    if (prefixedMethods.length === 0) {
+      throw new Error(`No methods found with prefix ${this.prefix}`);
+    }
+
+    return prefixedMethods[0].split('_')[1] as `v${number}`;
+  }
+}

--- a/packages/api/src/json-rpc/group/Transaction.ts
+++ b/packages/api/src/json-rpc/group/Transaction.ts
@@ -1,0 +1,30 @@
+import { JsonRpcGroup, JsonRpcGroupOptions } from './JsonRpcGroup.js';
+import { IJsonRpcClient, TxBroadcaster } from '../../types.js';
+import { OperationId } from '@dedot/specs';
+import { assert, HexString } from '@dedot/utils';
+import { Unsub } from '@dedot/types';
+
+export class Transaction extends JsonRpcGroup implements TxBroadcaster {
+  constructor(client: IJsonRpcClient, options?: Partial<JsonRpcGroupOptions>) {
+    super(client, { prefix: 'transaction', supportedVersions: ['unstable', 'v1'], ...options });
+  }
+
+  async broadcastTx(tx: HexString): Promise<Unsub> {
+    const operationId = await this.broadcast(tx);
+
+    return () => {
+      return this.stop(operationId);
+    };
+  }
+
+  async broadcast(tx: string): Promise<OperationId> {
+    const operationId = await this.send('broadcast', tx);
+    assert(operationId, 'Maximum number of broadcasted transactions has been reached');
+
+    return operationId;
+  }
+
+  stop(operationId: OperationId): Promise<void> {
+    return this.send('stop', operationId);
+  }
+}

--- a/packages/api/src/json-rpc/group/TransactionWatch.ts
+++ b/packages/api/src/json-rpc/group/TransactionWatch.ts
@@ -1,0 +1,19 @@
+import { TransactionWatchEvent } from '@dedot/specs';
+import { Callback, Unsub } from '@dedot/types';
+import { HexString, noop } from '@dedot/utils';
+import { IJsonRpcClient, TxBroadcaster } from '../../types.js';
+import { JsonRpcGroup, JsonRpcGroupOptions } from './JsonRpcGroup.js';
+
+export class TransactionWatch extends JsonRpcGroup implements TxBroadcaster {
+  constructor(client: IJsonRpcClient, options?: Partial<JsonRpcGroupOptions>) {
+    super(client, { prefix: 'transactionWatch', supportedVersions: ['unstable'], ...options });
+  }
+
+  broadcastTx(tx: HexString): Promise<Unsub> {
+    return this.submitAndWatch(tx, noop);
+  }
+
+  async submitAndWatch(tx: HexString, callback: Callback<TransactionWatchEvent>): Promise<Unsub> {
+    return this.send('submitAndWatch', tx, callback);
+  }
+}

--- a/packages/api/src/json-rpc/group/__tests__/ChainSpec.spec.ts
+++ b/packages/api/src/json-rpc/group/__tests__/ChainSpec.spec.ts
@@ -1,0 +1,57 @@
+import { stringToHex } from '@dedot/utils';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import MockProvider from '../../../client/__tests__/MockProvider';
+import { IJsonRpcClient } from '../../../types.js';
+import { JsonRpcClient } from '../../JsonRpcClient';
+import { ChainSpec } from '../ChainSpec';
+
+const rpcMethods = ['chainSpec_v1_chainName', 'chainSpec_v1_genesisHash', 'chainSpec_v1_properties'];
+
+describe('ChainSpec', () => {
+  let provider: MockProvider;
+  let client: IJsonRpcClient;
+
+  beforeEach(() => {
+    provider = new MockProvider();
+    provider.setRpcRequests({
+      rpc_methods: () => ({ methods: rpcMethods }),
+      chainSpec_v1_chainName: () => 'Mocked chain name',
+      chainSpec_v1_genesisHash: () => stringToHex('DEDOT'),
+      chainSpec_v1_properties: () => ({
+        ss58Format: 42,
+        tokenDecimals: 12,
+        tokenSymbol: 'DOT',
+      }),
+    });
+
+    client = new JsonRpcClient({ provider });
+  });
+
+  it('should return chainName', async () => {
+    const providerSend = vi.spyOn(client.provider, 'send');
+    const chainSpec = new ChainSpec(client);
+    const chainName = await chainSpec.chainName();
+    expect(chainName).toBe('Mocked chain name');
+    expect(providerSend).toBeCalledWith('chainSpec_v1_chainName', []);
+  });
+
+  it('should return genesisHash', async () => {
+    const providerSend = vi.spyOn(client.provider, 'send');
+    const chainSpec = new ChainSpec(client);
+    const genesisHash = await chainSpec.genesisHash();
+    expect(genesisHash).toBe(stringToHex('DEDOT'));
+    expect(providerSend).toBeCalledWith('chainSpec_v1_genesisHash', []);
+  });
+
+  it('should return properties', async () => {
+    const providerSend = vi.spyOn(client.provider, 'send');
+    const chainSpec = new ChainSpec(client);
+    const properties = await chainSpec.properties();
+    expect(properties).toEqual({
+      ss58Format: 42,
+      tokenDecimals: 12,
+      tokenSymbol: 'DOT',
+    });
+    expect(providerSend).toBeCalledWith('chainSpec_v1_properties', []);
+  });
+});

--- a/packages/api/src/json-rpc/group/__tests__/JsonRpcGroup.spec.ts
+++ b/packages/api/src/json-rpc/group/__tests__/JsonRpcGroup.spec.ts
@@ -1,0 +1,72 @@
+import { JsonRpcClient } from 'dedot';
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+import MockProvider from '../../../client/__tests__/MockProvider';
+import { IJsonRpcClient } from '../../../types.js';
+import { JsonRpcGroup, JsonRpcGroupOptions } from '../JsonRpcGroup';
+
+const rpcMethods = ['test_unstable_method', 'test_unstable_anotherMethod'];
+
+describe('JsonRpcGroup', () => {
+  let client: IJsonRpcClient;
+  let options: JsonRpcGroupOptions;
+
+  beforeEach(() => {
+    client = new JsonRpcClient({ provider: new MockProvider() });
+    options = {
+      prefix: 'test',
+      supportedVersions: ['unstable', 'v1'],
+      rpcMethods,
+    };
+  });
+
+  it('should detect version correctly', async () => {
+    const group = new JsonRpcGroup(client, options);
+    const version = await group.version();
+    expect(version).toBe('unstable');
+  });
+
+  it('should throw error when detected version is not supported', async () => {
+    options.supportedVersions = ['v1'];
+    const group = new JsonRpcGroup(client, options);
+    await expect(group.version()).rejects.toThrow();
+  });
+
+  it('should return true when group is supported', async () => {
+    const group = new JsonRpcGroup(client, options);
+    const isSupported = await group.supported();
+    expect(isSupported).toBe(true);
+  });
+
+  it('should return false when group is not supported', async () => {
+    options.supportedVersions = ['v1'];
+    const group = new JsonRpcGroup(client, options);
+    const isSupported = await group.supported();
+    expect(isSupported).toBe(false);
+  });
+
+  it('should send json-rpc request correctly', async () => {
+    (client.provider as MockProvider).setRpcRequest('test_unstable_method', () => '0x');
+    const providerSend = vi.spyOn(client.provider, 'send');
+
+    const group = new JsonRpcGroup(client, options);
+    await group.send('method', 'param1', 'param2');
+
+    expect(providerSend).toBeCalledWith('test_unstable_method', ['param1', 'param2']);
+  });
+
+  it('should send request using the fixed version', async () => {
+    (client.provider as MockProvider).setRpcRequest('test_v1_method', () => {
+      throw new Error('Method not found');
+    });
+
+    options.fixedVersion = 'v1';
+    options.supportedVersions = undefined;
+
+    const providerSend = vi.spyOn(client.provider, 'send');
+
+    const group = new JsonRpcGroup(client, options);
+    await expect(group.send('method', 'param1', 'param2')).rejects.toThrow();
+
+    expect(providerSend).toBeCalledWith('test_v1_method', ['param1', 'param2']);
+  });
+});

--- a/packages/api/src/json-rpc/group/index.ts
+++ b/packages/api/src/json-rpc/group/index.ts
@@ -1,0 +1,4 @@
+export * from './JsonRpcGroup.js';
+export * from './ChainSpec.js';
+export * from './Transaction.js';
+export * from './TransactionWatch.js';

--- a/packages/api/src/json-rpc/index.ts
+++ b/packages/api/src/json-rpc/index.ts
@@ -1,1 +1,2 @@
 export * from './JsonRpcClient.js';
+export * from './group/index.js';

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -3,7 +3,7 @@ import type { ConnectionStatus, JsonRpcProvider, ProviderEvent } from '@dedot/pr
 import type { AnyShape } from '@dedot/shape';
 import { SubscriptionsInfo } from '@dedot/specs';
 import type { IStorage } from '@dedot/storage';
-import type { GenericSubstrateApi, RuntimeApiName, RuntimeApiSpec } from '@dedot/types';
+import type { GenericSubstrateApi, RuntimeApiName, RuntimeApiSpec, Unsub } from '@dedot/types';
 import type { HashFn, HexString, IEventEmitter } from '@dedot/utils';
 import type { AnySignedExtension } from './extrinsic/index.js';
 
@@ -74,16 +74,13 @@ export interface SubstrateRuntimeVersion {
   transactionVersion: number;
 }
 
-export interface SubstrateChainProperties {
-  isEthereum?: boolean;
-  ss58Format?: number;
-  tokenDecimals?: number | Array<number>;
-  tokenSymbol?: string | Array<string>;
-  [prop: string]: any;
-}
-
-export interface IJsonRpcClient<ChainApi extends GenericSubstrateApi, Events extends string = ProviderEvent>
-  extends IEventEmitter<Events> {
+/**
+ * A generic interface for JSON-RPC clients
+ */
+export interface IJsonRpcClient<
+  ChainApi extends GenericSubstrateApi = GenericSubstrateApi,
+  Events extends string = ProviderEvent,
+> extends IEventEmitter<Events> {
   options: JsonRpcClientOptions;
   status: ConnectionStatus;
   provider: JsonRpcProvider;
@@ -93,7 +90,10 @@ export interface IJsonRpcClient<ChainApi extends GenericSubstrateApi, Events ext
   rpc: ChainApi['rpc'];
 }
 
-export interface ISubstrateClientAt<ChainApi extends GenericSubstrateApi> {
+/**
+ * A generic interface for Substrate clients at a specific block
+ */
+export interface ISubstrateClientAt<ChainApi extends GenericSubstrateApi = GenericSubstrateApi> {
   atBlockHash?: BlockHash;
 
   options: ApiOptions;
@@ -110,10 +110,33 @@ export interface ISubstrateClientAt<ChainApi extends GenericSubstrateApi> {
   errors: ChainApi['errors'];
 }
 
-export interface ISubstrateClient<ChainApi extends GenericSubstrateApi, Events extends string = ApiEvent>
-  extends IJsonRpcClient<ChainApi, Events>,
+/**
+ * A generic interface for Substrate clients
+ */
+export interface ISubstrateClient<
+  ChainApi extends GenericSubstrateApi = GenericSubstrateApi,
+  Events extends string = ApiEvent,
+> extends IJsonRpcClient<ChainApi, Events>,
     ISubstrateClientAt<ChainApi> {
   options: ApiOptions;
   tx: ChainApi['tx'];
   at<ChainApiAt extends GenericSubstrateApi = ChainApi>(hash: BlockHash): Promise<ISubstrateClientAt<ChainApiAt>>;
+}
+
+/**
+ * A generic interface for broadcasting transactions
+ */
+export interface TxBroadcaster {
+  /**
+   * Broadcast a transaction to the network
+   * @param tx
+   * @returns {Unsub} A function to stop broadcasting the transaction
+   */
+  broadcastTx(tx: HexString): Promise<Unsub>;
+
+  /**
+   * Check if this broadcaster is supported,
+   * We should check this before broadcasting a transaction
+   */
+  supported(): Promise<boolean>;
 }

--- a/packages/utils/src/deferred.ts
+++ b/packages/utils/src/deferred.ts
@@ -1,0 +1,23 @@
+import { noop } from './misc.js';
+
+export type Deferred<T> = {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (err: Error) => void;
+};
+
+export function deferred<T>(): Deferred<T> {
+  let resolve: (value: T) => void = noop;
+  let reject: (error?: Error) => void = noop;
+
+  const promise = new Promise<T>((_resolve, _reject) => {
+    resolve = _resolve;
+    reject = _reject;
+  });
+
+  return {
+    promise,
+    resolve,
+    reject,
+  };
+}

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -13,3 +13,4 @@ export * from './number.js';
 export * from './concat.js';
 export * from './to.js';
 export * from './misc.js';
+export * from './deferred.js';

--- a/packages/utils/src/misc.ts
+++ b/packages/utils/src/misc.ts
@@ -17,3 +17,8 @@ export const calcRuntimeApiHash = (runtimeApiName: string): HexString => {
 export function normalizeName(ident: string): string {
   return stringCamelCase(ident.replace('#', '_'));
 }
+
+/**
+ * Simply does nothing
+ */
+export function noop() {}

--- a/zombienet-tests/src/0001-small-network.zndsl
+++ b/zombienet-tests/src/0001-small-network.zndsl
@@ -10,3 +10,4 @@ alice: ts-script ./0001-check-storage-query.ts within 100 seconds
 alice: ts-script ./0001-check-tx-transfer-balance.ts within 100 seconds
 alice: ts-script ./0001-check-tx-batch.ts within 100 seconds
 alice: ts-script ./0001-check-ws-provider-connection.ts within 100 seconds
+alice: ts-script ./0001-tx-broadcaster.ts within 100 seconds

--- a/zombienet-tests/src/0001-tx-broadcaster.ts
+++ b/zombienet-tests/src/0001-tx-broadcaster.ts
@@ -1,0 +1,51 @@
+import Keyring from '@polkadot/keyring';
+import { cryptoWaitReady } from '@polkadot/util-crypto';
+import { HexString, stringToHex } from '@dedot/utils';
+import { Dedot, Transaction, TransactionWatch } from 'dedot';
+
+const prepareRemarkTx = async (api: Dedot): Promise<{ rawTx: HexString; sender: string }> => {
+  await cryptoWaitReady();
+  const keyring = new Keyring({ type: 'sr25519' });
+  const alice = keyring.addFromUri('//Alice');
+
+  const remarkTx = api.tx.system.remarkWithEvent('Hello world');
+  await remarkTx.sign(alice);
+
+  return {
+    rawTx: remarkTx.toHex(),
+    sender: alice.address,
+  };
+};
+
+export const run = async (nodeName: any, networkInfo: any): Promise<void> => {
+  const { wsUri: endpoint } = networkInfo.nodesByName[nodeName];
+
+  const api = await Dedot.new(endpoint);
+
+  const getTxBroadcaster = async () => {
+    const transaction = new Transaction(api);
+    if (await transaction.supported()) return transaction;
+
+    const txWatch = new TransactionWatch(api);
+    if (await txWatch.supported()) return txWatch;
+
+    throw new Error('Transaction broadcaster not supported');
+  };
+  const txBroadcaster = await getTxBroadcaster();
+
+  const { rawTx, sender: senderAddress } = await prepareRemarkTx(api);
+
+  const unsub = await txBroadcaster.broadcastTx(rawTx);
+
+  await api.query.system.events((events) => {
+    events.forEach(({ event }) => {
+      if (api.events.system.Remarked.is(event)) {
+        const { sender, hash } = event.palletEvent.data;
+        if (sender.address() === senderAddress && api.registry.hashAsHex(stringToHex('Hello world')) === hash) {
+          console.log('Remark event found, stop broadcasting now!');
+          unsub();
+        }
+      }
+    });
+  });
+};

--- a/zombienet-tests/src/0001-tx-broadcaster.ts
+++ b/zombienet-tests/src/0001-tx-broadcaster.ts
@@ -32,6 +32,8 @@ export const run = async (nodeName: any, networkInfo: any): Promise<any> => {
 
     const { rawTx, sender: senderAddress } = await prepareRemarkTx(api);
 
+    // @ts-ignore
+    console.log(`Broadcasting tx using ${txBroadcaster.prefix}-prefixed broadcaster`);
     const stopBroadcast = await txBroadcaster.broadcastTx(rawTx);
 
     const unsub = await api.query.system.events((events) => {

--- a/zombienet-tests/src/0001-tx-broadcaster.ts
+++ b/zombienet-tests/src/0001-tx-broadcaster.ts
@@ -25,20 +25,22 @@ export const run = async (nodeName: any, networkInfo: any): Promise<any> => {
   const broadcastUntilRemark = async (txBroadcaster: TxBroadcaster) => {
     const defer = deferred<void>();
     if (!(await txBroadcaster.supported())) {
-      console.log(`${txBroadcaster} broadcaster is not supported, skip it!`);
+      // @ts-ignore
+      console.log(`${txBroadcaster.prefix}-prefixed broadcaster is not supported, skip it!`);
       return defer.resolve();
     }
 
     const { rawTx, sender: senderAddress } = await prepareRemarkTx(api);
 
-    const unsub = await txBroadcaster.broadcastTx(rawTx);
+    const stopBroadcast = await txBroadcaster.broadcastTx(rawTx);
 
-    await api.query.system.events((events) => {
+    const unsub = await api.query.system.events((events) => {
       events.forEach(({ event }) => {
         if (api.events.system.Remarked.is(event)) {
           const { sender, hash } = event.palletEvent.data;
           if (sender.address() === senderAddress && api.registry.hashAsHex(stringToHex('Hello world')) === hash) {
             console.log('Remark event found, stop broadcasting now!');
+            stopBroadcast();
             unsub();
             defer.resolve();
           }


### PR DESCRIPTION
We're adding a `JsonRpcGroup` abstraction to help dealing with multi-version supported nature of the [new json rpc spec](https://paritytech.github.io/json-rpc-interface-spec/grouping-functions-and-node-capabilities.html).

The `JsonRpcGroup` help us:
- Detect the supported version a spefic prefixed json-rpc group
- Send a json-rpc method in the group without having to specify the prefix & version.

On top of this we're adding a new high-level abstraction for existing json-rpc group like: ChainSpec, Transaction & TransactionWatch


