### PR TITLE
tweak!: remove `WsProvider` tight coupling

### DIFF
--- a/packages/api/src/client/BaseSubstrateClient.ts
+++ b/packages/api/src/client/BaseSubstrateClient.ts
@@ -13,7 +13,6 @@ import type {
   ISubstrateClientAt,
   JsonRpcClientOptions,
   MetadataKey,
-  NetworkEndpoint,
   SubstrateRuntimeVersion,
 } from '../types.js';
 
@@ -46,20 +45,15 @@ export abstract class BaseSubstrateClient<ChainApi extends VersionedGenericSubst
 
   protected constructor(
     public rpcVersion: RpcVersion,
-    options: JsonRpcClientOptions | NetworkEndpoint,
+    options: JsonRpcClientOptions,
   ) {
     super(options);
     this._options = this.normalizeOptions(options);
   }
 
   /// --- Internal logics
-  protected normalizeOptions(options: ApiOptions | NetworkEndpoint): ApiOptions {
-    const defaultOptions = { throwOnUnknownApi: true };
-    if (typeof options === 'string') {
-      return { ...defaultOptions, endpoint: options };
-    } else {
-      return { ...defaultOptions, ...options } as ApiOptions;
-    }
+  protected normalizeOptions(options: ApiOptions): ApiOptions {
+    return { throwOnUnknownApi: true, ...options } as ApiOptions;
   }
 
   protected async initializeLocalCache() {

--- a/packages/api/src/client/BaseSubstrateClient.ts
+++ b/packages/api/src/client/BaseSubstrateClient.ts
@@ -1,5 +1,5 @@
 import { $Metadata, BlockHash, Hash, Metadata, PortableRegistry } from '@dedot/codecs';
-import { JsonRpcProvider } from '@dedot/providers';
+import type { JsonRpcProvider } from '@dedot/providers';
 import { type IStorage, LocalStorage } from '@dedot/storage';
 import { GenericSubstrateApi, RpcVersion, VersionedGenericSubstrateApi } from '@dedot/types';
 import { calcRuntimeApiHash, ensurePresence as _ensurePresence, u8aToHex } from '@dedot/utils';

--- a/packages/api/src/client/Dedot.ts
+++ b/packages/api/src/client/Dedot.ts
@@ -1,4 +1,5 @@
 import { BlockHash, PortableRegistry, RuntimeVersion } from '@dedot/codecs';
+import type { JsonRpcProvider } from '@dedot/providers';
 import { GenericSubstrateApi, RpcLegacy, Unsub, VersionedGenericSubstrateApi } from '@dedot/types';
 import type { SubstrateApi } from '../chaintypes/index.js';
 import {
@@ -63,7 +64,7 @@ export class Dedot<ChainApi extends VersionedGenericSubstrateApi = SubstrateApi>
    *
    * @param options
    */
-  constructor(options: ApiOptions) {
+  constructor(options: ApiOptions | JsonRpcProvider) {
     super('legacy', options);
   }
 
@@ -73,7 +74,7 @@ export class Dedot<ChainApi extends VersionedGenericSubstrateApi = SubstrateApi>
    * @param options
    */
   static async create<ChainApi extends VersionedGenericSubstrateApi = SubstrateApi>(
-    options: ApiOptions,
+    options: ApiOptions | JsonRpcProvider,
   ): Promise<Dedot<ChainApi>> {
     return new Dedot<ChainApi>(options).connect();
   }
@@ -84,7 +85,7 @@ export class Dedot<ChainApi extends VersionedGenericSubstrateApi = SubstrateApi>
    * @param options
    */
   static async new<ChainApi extends VersionedGenericSubstrateApi = SubstrateApi>(
-    options: ApiOptions,
+    options: ApiOptions | JsonRpcProvider,
   ): Promise<Dedot<ChainApi>> {
     return Dedot.create(options);
   }

--- a/packages/api/src/client/Dedot.ts
+++ b/packages/api/src/client/Dedot.ts
@@ -10,7 +10,7 @@ import {
   TxExecutor,
 } from '../executor/index.js';
 import { newProxyChain } from '../proxychain.js';
-import type { ApiOptions, ISubstrateClientAt, NetworkEndpoint, SubstrateRuntimeVersion } from '../types.js';
+import type { ApiOptions, ISubstrateClientAt, SubstrateRuntimeVersion } from '../types.js';
 import { BaseSubstrateClient } from './BaseSubstrateClient.js';
 
 const KEEP_ALIVE_INTERVAL = 10_000; // in ms
@@ -63,7 +63,7 @@ export class Dedot<ChainApi extends VersionedGenericSubstrateApi = SubstrateApi>
    *
    * @param options
    */
-  constructor(options: ApiOptions | NetworkEndpoint) {
+  constructor(options: ApiOptions) {
     super('legacy', options);
   }
 
@@ -73,7 +73,7 @@ export class Dedot<ChainApi extends VersionedGenericSubstrateApi = SubstrateApi>
    * @param options
    */
   static async create<ChainApi extends VersionedGenericSubstrateApi = SubstrateApi>(
-    options: ApiOptions | NetworkEndpoint,
+    options: ApiOptions,
   ): Promise<Dedot<ChainApi>> {
     return new Dedot<ChainApi>(options).connect();
   }
@@ -84,7 +84,7 @@ export class Dedot<ChainApi extends VersionedGenericSubstrateApi = SubstrateApi>
    * @param options
    */
   static async new<ChainApi extends VersionedGenericSubstrateApi = SubstrateApi>(
-    options: ApiOptions | NetworkEndpoint,
+    options: ApiOptions,
   ): Promise<Dedot<ChainApi>> {
     return Dedot.create(options);
   }

--- a/packages/api/src/client/DedotClient.ts
+++ b/packages/api/src/client/DedotClient.ts
@@ -6,7 +6,7 @@ import type { SubstrateApi } from '../chaintypes/index.js';
 import { RuntimeApiExecutorV2, StorageQueryExecutorV2, TxExecutorV2 } from '../executor/index.js';
 import { ChainHead, ChainSpec, PinnedBlock, Transaction, TransactionWatch } from '../json-rpc/index.js';
 import { newProxyChain } from '../proxychain.js';
-import type { ApiOptions, NetworkEndpoint, TxBroadcaster } from '../types.js';
+import type { ApiOptions, TxBroadcaster } from '../types.js';
 import { BaseSubstrateClient, ensurePresence } from './BaseSubstrateClient.js';
 
 /**
@@ -27,7 +27,7 @@ export class DedotClient<
    *
    * @param options
    */
-  constructor(options: ApiOptions | NetworkEndpoint) {
+  constructor(options: ApiOptions) {
     super('v2', options);
   }
 
@@ -37,7 +37,7 @@ export class DedotClient<
    * @param options
    */
   static async create<ChainApi extends VersionedGenericSubstrateApi = SubstrateApi>(
-    options: ApiOptions | NetworkEndpoint,
+    options: ApiOptions,
   ): Promise<DedotClient<ChainApi>> {
     return new DedotClient<ChainApi>(options).connect();
   }
@@ -48,7 +48,7 @@ export class DedotClient<
    * @param options
    */
   static async new<ChainApi extends VersionedGenericSubstrateApi = SubstrateApi>(
-    options: ApiOptions | NetworkEndpoint,
+    options: ApiOptions,
   ): Promise<DedotClient<ChainApi>> {
     return DedotClient.create(options);
   }

--- a/packages/api/src/client/DedotClient.ts
+++ b/packages/api/src/client/DedotClient.ts
@@ -1,4 +1,5 @@
 import { $H256, BlockHash } from '@dedot/codecs';
+import type { JsonRpcProvider } from '@dedot/providers';
 import { u32 } from '@dedot/shape';
 import { RpcV2, VersionedGenericSubstrateApi } from '@dedot/types';
 import { assert, concatU8a, HexString, noop, twox64Concat, u8aToHex, xxhashAsU8a } from '@dedot/utils';
@@ -27,7 +28,7 @@ export class DedotClient<
    *
    * @param options
    */
-  constructor(options: ApiOptions) {
+  constructor(options: ApiOptions | JsonRpcProvider) {
     super('v2', options);
   }
 
@@ -37,7 +38,7 @@ export class DedotClient<
    * @param options
    */
   static async create<ChainApi extends VersionedGenericSubstrateApi = SubstrateApi>(
-    options: ApiOptions,
+    options: ApiOptions | JsonRpcProvider,
   ): Promise<DedotClient<ChainApi>> {
     return new DedotClient<ChainApi>(options).connect();
   }
@@ -48,7 +49,7 @@ export class DedotClient<
    * @param options
    */
   static async new<ChainApi extends VersionedGenericSubstrateApi = SubstrateApi>(
-    options: ApiOptions,
+    options: ApiOptions | JsonRpcProvider,
   ): Promise<DedotClient<ChainApi>> {
     return DedotClient.create(options);
   }

--- a/packages/api/src/client/__tests__/Dedot.spec.ts
+++ b/packages/api/src/client/__tests__/Dedot.spec.ts
@@ -1,4 +1,5 @@
 import type { RuntimeVersion } from '@dedot/codecs';
+import { WsProvider } from '@dedot/providers';
 import type { AnyShape } from '@dedot/shape';
 import * as $ from '@dedot/shape';
 import { stringCamelCase, stringPascalCase, u8aToHex } from '@dedot/utils';
@@ -9,7 +10,7 @@ import MockProvider, { MockedRuntimeVersion } from './MockProvider.js';
 describe('Dedot', () => {
   it('should throws error for invalid endpoint', () => {
     expect(async () => {
-      await Dedot.new('invalid_endpoint');
+      await Dedot.new(new WsProvider('invalid_endpoint'));
     }).rejects.toThrowError(
       'Invalid websocket endpoint invalid_endpoint, a valid endpoint should start with wss:// or ws://',
     );

--- a/packages/api/src/client/__tests__/DedotClient.spec.ts
+++ b/packages/api/src/client/__tests__/DedotClient.spec.ts
@@ -1,6 +1,6 @@
 import staticSubstrateV15 from '@polkadot/types-support/metadata/v15/substrate-hex';
-import { ormlTokens } from '@polkadot/types/interfaces/definitions';
 import { $Metadata } from '@dedot/codecs';
+import { WsProvider } from '@dedot/providers';
 import type { AnyShape } from '@dedot/shape';
 import * as $ from '@dedot/shape';
 import { MethodResponse, OperationCallDone } from '@dedot/specs';
@@ -18,7 +18,7 @@ const prefixedMetadataV15 = u8aToHex(
 describe('DedotClient', () => {
   it('should throws error for invalid endpoint', () => {
     expect(async () => {
-      await DedotClient.new('invalid_endpoint');
+      await DedotClient.new(new WsProvider('invalid_endpoint'));
     }).rejects.toThrowError(
       'Invalid websocket endpoint invalid_endpoint, a valid endpoint should start with wss:// or ws://',
     );

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -8,7 +8,7 @@ export * from './json-rpc/index.js';
 export * from './client/index.js';
 
 // Re-exports
-export { WsProvider } from '@dedot/providers';
+export { WsProvider, SmoldotProvider } from '@dedot/providers';
 export * as $ from '@dedot/shape';
 export * from '@dedot/codecs';
 export * from '@dedot/utils';

--- a/packages/api/src/json-rpc/JsonRpcClient.ts
+++ b/packages/api/src/json-rpc/JsonRpcClient.ts
@@ -1,9 +1,9 @@
-import { ConnectionStatus, JsonRpcProvider, ProviderEvent, Subscription, WsProvider } from '@dedot/providers';
+import type { ConnectionStatus, JsonRpcProvider, ProviderEvent, Subscription } from '@dedot/providers';
 import { scaledResponses, subscriptionsInfo } from '@dedot/specs';
-import { AsyncMethod, GenericSubstrateApi, RpcVersion, Unsub } from '@dedot/types';
+import type { AsyncMethod, GenericSubstrateApi, RpcVersion, Unsub } from '@dedot/types';
 import { assert, EventEmitter, isFunction } from '@dedot/utils';
-import { SubstrateApi } from '../chaintypes/index.js';
-import { IJsonRpcClient, JsonRpcClientOptions, NetworkEndpoint } from '../types.js';
+import type { SubstrateApi } from '../chaintypes/index.js';
+import type { IJsonRpcClient, JsonRpcClientOptions } from '../types.js';
 
 export class JsonRpcClient<
     ChainApi extends GenericSubstrateApi = SubstrateApi[RpcVersion],
@@ -15,11 +15,12 @@ export class JsonRpcClient<
   readonly #options: JsonRpcClientOptions;
   readonly #provider: JsonRpcProvider;
 
-  constructor(options: JsonRpcClientOptions | NetworkEndpoint) {
+  constructor(options: JsonRpcClientOptions) {
     super();
+    assert(options.provider, 'A JsonRpcProvider is required');
 
-    this.#options = typeof options === 'string' ? { endpoint: options } : options;
-    this.#provider = this.#getProvider();
+    this.#options = options;
+    this.#provider = options.provider;
   }
 
   /**
@@ -28,7 +29,7 @@ export class JsonRpcClient<
    * @param options
    */
   static async create<ChainApi extends GenericSubstrateApi = SubstrateApi[RpcVersion]>(
-    options: JsonRpcClientOptions | NetworkEndpoint,
+    options: JsonRpcClientOptions,
   ): Promise<JsonRpcClient<ChainApi>> {
     return new JsonRpcClient<ChainApi>(options).connect();
   }
@@ -39,7 +40,7 @@ export class JsonRpcClient<
    * @param options
    */
   static async new<ChainApi extends GenericSubstrateApi = SubstrateApi[RpcVersion]>(
-    options: JsonRpcClientOptions | NetworkEndpoint,
+    options: JsonRpcClientOptions,
   ): Promise<JsonRpcClient<ChainApi>> {
     return JsonRpcClient.create(options);
   }
@@ -109,15 +110,6 @@ export class JsonRpcClient<
   async disconnect(): Promise<void> {
     await this.#provider.disconnect();
     this.clearEvents();
-  }
-
-  #getProvider(): JsonRpcProvider {
-    const { provider, endpoint } = this.#options;
-    if (provider) return provider;
-    if (endpoint) return new WsProvider(endpoint);
-
-    // TODO support light-client
-    return new WsProvider('ws://127.0.0.1:9944');
   }
 
   /**

--- a/packages/api/src/json-rpc/group/ChainHead/ChainHead.ts
+++ b/packages/api/src/json-rpc/group/ChainHead/ChainHead.ts
@@ -1,6 +1,6 @@
 import { $Header, BlockHash, Option } from '@dedot/codecs';
-import { Subscription } from '@dedot/providers';
-import {
+import type { Subscription } from '@dedot/providers';
+import type {
   ChainHeadRuntimeVersion,
   FollowEvent,
   FollowOperationEvent,
@@ -10,10 +10,10 @@ import {
   StorageQuery,
   StorageResult,
 } from '@dedot/specs';
-import { AsyncMethod, Unsub } from '@dedot/types';
+import type { AsyncMethod, Unsub } from '@dedot/types';
 import { assert, Deferred, deferred, ensurePresence, HexString, noop, AsyncQueue } from '@dedot/utils';
-import { IJsonRpcClient } from '../../../types.js';
-import { JsonRpcGroup, JsonRpcGroupOptions } from '../JsonRpcGroup.js';
+import type { IJsonRpcClient } from '../../../types.js';
+import { JsonRpcGroup, type JsonRpcGroupOptions } from '../JsonRpcGroup.js';
 import {
   ChainHeadBlockNotPinnedError,
   ChainHeadError,

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -7,18 +7,13 @@ import type { GenericSubstrateApi, RpcVersion, RuntimeApiName, RuntimeApiSpec, U
 import type { HashFn, HexString, IEventEmitter } from '@dedot/utils';
 import type { AnySignedExtension } from './extrinsic/index.js';
 
-export type NetworkEndpoint = string;
 export type MetadataKey = `RAW_META/${string}`;
 
 export interface JsonRpcClientOptions {
-  provider?: JsonRpcProvider;
   /**
-   * @description A `ProviderInterface` will be created based on the supplied endpoint.
-   * If both `provider` and `endpoint` is provided, the `provider` will be used for connection.
-   *
-   * A valid endpoint should start with `wss://`, `ws://`, `https://` or `http://`
+   * @description A JSON-RPC provider instance, it could be a `WsProvider` or `SmoldotProvider`
    */
-  endpoint?: NetworkEndpoint;
+  provider: JsonRpcProvider;
   subscriptions?: SubscriptionsInfo;
   scaledResponses?: Record<string, AnyShape>;
 }

--- a/packages/codegen/src/index.ts
+++ b/packages/codegen/src/index.ts
@@ -1,7 +1,7 @@
 import { MetadataLatest } from '@dedot/codecs';
 import { RpcMethods } from '@dedot/specs';
 import { stringCamelCase } from '@dedot/utils';
-import { Dedot } from 'dedot';
+import { Dedot, WsProvider } from 'dedot';
 import * as fs from 'fs';
 import * as path from 'path';
 import {
@@ -22,7 +22,7 @@ export async function generateTypesFromEndpoint(
   outDir?: string,
   extension: string = 'd.ts',
 ) {
-  const api = await Dedot.new(endpoint);
+  const api = await Dedot.new(new WsProvider(endpoint));
   const { methods }: RpcMethods = await api.rpc.rpc_methods();
   const apis = api.runtimeVersion.apis || {};
   if (!chain) {

--- a/packages/providers/src/ws/WsProvider.ts
+++ b/packages/providers/src/ws/WsProvider.ts
@@ -6,6 +6,7 @@ import { JsonRpcRequest } from '../types.js';
 export interface WsProviderOptions {
   /**
    * The websocket endpoint to connect to
+   * A valid endpoint should start with `wss://`, `ws://`
    *
    * @required
    */

--- a/zombienet-tests/src/0001-check-runtime-api.ts
+++ b/zombienet-tests/src/0001-check-runtime-api.ts
@@ -1,7 +1,7 @@
 import { $Metadata, Metadata } from '@dedot/codecs';
 import { RpcVersion } from '@dedot/types';
 import { assert, stringCamelCase } from '@dedot/utils';
-import { Dedot, DedotClient, ISubstrateClient } from 'dedot';
+import { Dedot, DedotClient, ISubstrateClient, WsProvider } from 'dedot';
 import { SubstrateApi } from 'dedot/chaintypes';
 
 const ALICE = '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY';
@@ -42,9 +42,9 @@ const verifyRuntimeApi = async (api: ISubstrateClient<SubstrateApi[RpcVersion]>)
 export const run = async (nodeName: any, networkInfo: any) => {
   const { wsUri } = networkInfo.nodesByName[nodeName];
 
-  const apiLegacy = await Dedot.new(wsUri);
+  const apiLegacy = await Dedot.new(new WsProvider(wsUri));
   await verifyRuntimeApi(apiLegacy);
 
-  const apiV2 = await DedotClient.new(wsUri);
+  const apiV2 = await DedotClient.new(new WsProvider(wsUri));
   await verifyRuntimeApi(apiV2);
 };

--- a/zombienet-tests/src/0001-check-storage-query-v2.ts
+++ b/zombienet-tests/src/0001-check-storage-query-v2.ts
@@ -1,5 +1,5 @@
 import { assert } from '@dedot/utils';
-import { DedotClient } from 'dedot';
+import { DedotClient, WsProvider } from 'dedot';
 
 const ALICE = '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY';
 const BOB = '5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty';
@@ -9,7 +9,7 @@ const addressesToCheck: Record<string, string> = { ALICE, BOB };
 export const run = async (nodeName: any, networkInfo: any) => {
   const { wsUri } = networkInfo.nodesByName[nodeName];
 
-  const api = await DedotClient.new(wsUri);
+  const api = await DedotClient.new(new WsProvider(wsUri));
 
   const balances = await api.query.system.account.multi([ALICE, BOB]);
 

--- a/zombienet-tests/src/0001-check-storage-query.ts
+++ b/zombienet-tests/src/0001-check-storage-query.ts
@@ -1,5 +1,5 @@
 import { assert } from '@dedot/utils';
-import { Dedot } from 'dedot';
+import { Dedot, WsProvider } from 'dedot';
 
 const ALICE = '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY';
 const BOB = '5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty';
@@ -9,7 +9,7 @@ const addressesToCheck: Record<string, string> = { ALICE, BOB };
 export const run = async (nodeName: any, networkInfo: any) => {
   const { wsUri } = networkInfo.nodesByName[nodeName];
 
-  const api = await Dedot.new(wsUri);
+  const api = await Dedot.new(new WsProvider(wsUri));
 
   const balances = await api.query.system.account.multi([ALICE, BOB]);
 

--- a/zombienet-tests/src/0001-check-tx-batch-v2.ts
+++ b/zombienet-tests/src/0001-check-tx-batch-v2.ts
@@ -3,7 +3,7 @@ import { cryptoWaitReady } from '@polkadot/util-crypto';
 import { RococoApi } from '@dedot/chaintypes';
 import { RococoRuntimeRuntimeCallLike } from '@dedot/chaintypes/rococo';
 import { assert, isHex, isNumber } from '@dedot/utils';
-import { Dedot, DedotClient } from 'dedot';
+import { Dedot, DedotClient, WsProvider } from 'dedot';
 
 const BOB = '5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty';
 
@@ -15,7 +15,7 @@ export const run = async (nodeName: any, networkInfo: any): Promise<void> => {
   const { wsUri } = networkInfo.nodesByName[nodeName];
 
   // TODO use RococoApi
-  const api = await DedotClient.new(wsUri);
+  const api = await DedotClient.new(new WsProvider(wsUri));
 
   const TEN_UNIT = BigInt(10 * 1e12);
 

--- a/zombienet-tests/src/0001-check-tx-batch.ts
+++ b/zombienet-tests/src/0001-check-tx-batch.ts
@@ -3,7 +3,7 @@ import { cryptoWaitReady } from '@polkadot/util-crypto';
 import { RococoApi } from '@dedot/chaintypes';
 import { RococoRuntimeRuntimeCallLike } from '@dedot/chaintypes/rococo';
 import { assert } from '@dedot/utils';
-import { Dedot } from 'dedot';
+import { Dedot, WsProvider } from 'dedot';
 
 const BOB = '5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty';
 
@@ -15,7 +15,7 @@ export const run = async (nodeName: any, networkInfo: any): Promise<void> => {
   const { wsUri } = networkInfo.nodesByName[nodeName];
 
   // TODO use RococoApi
-  const api = await Dedot.new(wsUri);
+  const api = await Dedot.new(new WsProvider(wsUri));
 
   const TEN_UNIT = BigInt(10 * 1e12);
 

--- a/zombienet-tests/src/0001-check-tx-transfer-balance-v2.ts
+++ b/zombienet-tests/src/0001-check-tx-transfer-balance-v2.ts
@@ -3,7 +3,7 @@ import { cryptoWaitReady } from '@polkadot/util-crypto';
 import { RococoApi } from '@dedot/chaintypes';
 import { TransactionStatusV2 } from '@dedot/types';
 import { assert, isHex, isNumber } from '@dedot/utils';
-import { Dedot, DedotClient } from 'dedot';
+import { Dedot, DedotClient, WsProvider } from 'dedot';
 
 const BOB = '5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty';
 
@@ -15,7 +15,7 @@ export const run = async (nodeName: any, networkInfo: any): Promise<void> => {
   const { wsUri } = networkInfo.nodesByName[nodeName];
 
   // TODO use RococoApi
-  const api = await DedotClient.new(wsUri);
+  const api = await DedotClient.new(new WsProvider(wsUri));
 
   const prevBobBalance = (await api.query.system.account(BOB)).data.free;
   console.log('BOB - old balance', prevBobBalance);

--- a/zombienet-tests/src/0001-check-tx-transfer-balance.ts
+++ b/zombienet-tests/src/0001-check-tx-transfer-balance.ts
@@ -2,7 +2,7 @@ import Keyring from '@polkadot/keyring';
 import { cryptoWaitReady } from '@polkadot/util-crypto';
 import { RococoApi } from '@dedot/chaintypes';
 import { assert } from '@dedot/utils';
-import { Dedot } from 'dedot';
+import { Dedot, WsProvider } from 'dedot';
 
 const BOB = '5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty';
 
@@ -14,7 +14,7 @@ export const run = async (nodeName: any, networkInfo: any): Promise<void> => {
   const { wsUri } = networkInfo.nodesByName[nodeName];
 
   // TODO use RococoApi
-  const api = await Dedot.new(wsUri);
+  const api = await Dedot.new(new WsProvider(wsUri));
 
   const prevBobBalance = (await api.query.system.account(BOB)).data.free;
   const prevBlockNumber = await api.query.system.number();

--- a/zombienet-tests/src/0001-tx-broadcaster.ts
+++ b/zombienet-tests/src/0001-tx-broadcaster.ts
@@ -1,7 +1,7 @@
 import Keyring from '@polkadot/keyring';
 import { cryptoWaitReady } from '@polkadot/util-crypto';
 import { deferred, HexString, stringToHex } from '@dedot/utils';
-import { Dedot, Transaction, TransactionWatch, TxBroadcaster } from 'dedot';
+import { Dedot, Transaction, TransactionWatch, TxBroadcaster, WsProvider } from 'dedot';
 
 const prepareRemarkTx = async (api: Dedot): Promise<{ rawTx: HexString; sender: string }> => {
   await cryptoWaitReady();
@@ -18,9 +18,9 @@ const prepareRemarkTx = async (api: Dedot): Promise<{ rawTx: HexString; sender: 
 };
 
 export const run = async (nodeName: any, networkInfo: any): Promise<any> => {
-  const { wsUri: endpoint } = networkInfo.nodesByName[nodeName];
+  const { wsUri } = networkInfo.nodesByName[nodeName];
 
-  const api = await Dedot.new(endpoint);
+  const api = await Dedot.new(new WsProvider(wsUri));
 
   const broadcastUntilRemark = async (txBroadcaster: TxBroadcaster) => {
     const defer = deferred<void>();

--- a/zombienet-tests/src/0001-verify-chain-head-logic.ts
+++ b/zombienet-tests/src/0001-verify-chain-head-logic.ts
@@ -10,6 +10,7 @@ import {
   QueryableStorage,
   AccountId32,
   PinnedBlock,
+  WsProvider,
 } from 'dedot';
 import { FrameSystemAccountInfo } from 'dedot/chaintypes';
 
@@ -17,9 +18,9 @@ const ALICE = '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY';
 const BOB = '5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty';
 
 export const run = async (nodeName: any, networkInfo: any): Promise<any> => {
-  const { wsUri: endpoint } = networkInfo.nodesByName[nodeName];
+  const { wsUri } = networkInfo.nodesByName[nodeName];
 
-  const client = await JsonRpcClient.new(endpoint);
+  const client = await JsonRpcClient.new(new WsProvider(wsUri));
   const chainHead = new ChainHead(client);
   await chainHead.follow();
 


### PR DESCRIPTION
This is a breaking change.

Rationale:
- Previously, `WsProvider` were tight coupled inside the JsonRpcClient which makes it more convenient when initialize the client by only feeding the endpoint url, e.g: `JsonRpcClient.new('wss://rpc.polkadot.io')`
- Now, we're having `SmoldotProvider`, so users might choose between 2 options. If `SmoldotProvder` is used, `WsProvider` should not be included inside the bundle and vise-versa via the tree-shaking process.
- TODO update docs & comments.