### PR TITLE
feat(api): chainHead responses caching

### DIFF
--- a/packages/api/src/json-rpc/group/ChainHead/ChainHead.ts
+++ b/packages/api/src/json-rpc/group/ChainHead/ChainHead.ts
@@ -595,7 +595,16 @@ export class ChainHead extends JsonRpcGroup<ChainHeadEvent> {
   async header(at?: BlockHash): Promise<Option<HexString>> {
     await this.#ensureFollowed();
 
-    return this.#getHeader(this.#ensurePinnedHash(at));
+    const hash = this.#ensurePinnedHash(at);
+    const cacheKey = `${hash}::header`;
+
+    if (this.#cache.has(cacheKey)) {
+      return this.#cache.get(cacheKey);
+    }
+
+    const resp = await this.#getHeader(hash);
+    this.#cache.set(cacheKey, resp);
+    return resp;
   }
 
   async #getHeader(at: BlockHash): Promise<Option<HexString>> {

--- a/packages/api/src/json-rpc/group/__tests__/ChainHead.spec.ts
+++ b/packages/api/src/json-rpc/group/__tests__/ChainHead.spec.ts
@@ -1489,7 +1489,7 @@ describe('ChainHead', () => {
 
       const bestHash = await chainHead.bestHash();
       const r1 = await chainHead.storage(queries, null, bestHash);
-      const r2 = await chainHead.storage(queries, null, bestHash);
+      const r2 = await chainHead.storage(queries, undefined, bestHash);
       const r3 = await chainHead.storage(queries, null, bestHash);
 
       expect(r1).toEqual(r2);


### PR DESCRIPTION
Caching supported for responses from these requests/operations:
- `chainHead_header`
- `chainHead_body`
- `chainHead_call`
- `chainHead_storage`