### PR TITLE
fix!: rename legacy client

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ _Note: The project is still in active development phase, the information on this
 - ✅ Native TypeScript type system for scale-codec
 - ✅ Compatible with `@polkadot/extension`-based wallets
 - ✅ Support Metadata V14, V15 (latest)
-- ✅ Support both the legacy & [new](https://paritytech.github.io/json-rpc-interface-spec/introduction.html) JSON-RPC APIs
+- ✅ Build on top of both the [new](https://paritytech.github.io/json-rpc-interface-spec/introduction.html) & legacy (deprecated soon) JSON-RPC Apis
 - ✅ Support light clients (e.g: [smoldot](https://www.npmjs.com/package/smoldot))
 - ⏳ Typed Contract APIs
 
@@ -91,6 +91,15 @@ const { DedotClient, WsProvider } = require('dedot');
 const provider = new WsProvider('wss://rpc.polkadot.io');
 const api = await DedotClient.new(provider);
 ```
+
+- If the JSON-RPC server doesn't support new JSON-RPC Apis, you can connect using the `LegacyClient` which using the legacy JSON-RPC Apis.
+```typescript
+import { LegacyClient, WsProvider } from 'dedot';
+
+const provider = new WsProvider('wss://rpc.polkadot.io');
+const api = await LegacyClient.new(provider);
+```
+
 ### Table of contents
 - [Status](#status)
 - [Chain Types & APIs](#chain-types--apis)

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ _Note: The project is still in active development phase, the information on this
 - ✅ Native TypeScript type system for scale-codec
 - ✅ Compatible with `@polkadot/extension`-based wallets
 - ✅ Support Metadata V14, V15 (latest)
-- ✅ Build on top of both the [new](https://paritytech.github.io/json-rpc-interface-spec/introduction.html) & legacy (deprecated soon) JSON-RPC Apis
+- ✅ Build on top of both the [new](https://paritytech.github.io/json-rpc-interface-spec/introduction.html) & legacy (deprecated soon) JSON-RPC APIs
 - ✅ Support light clients (e.g: [smoldot](https://www.npmjs.com/package/smoldot))
 - ⏳ Typed Contract APIs
 
@@ -92,7 +92,7 @@ const provider = new WsProvider('wss://rpc.polkadot.io');
 const api = await DedotClient.new(provider);
 ```
 
-- If the JSON-RPC server doesn't support new JSON-RPC Apis, you can connect using the `LegacyClient` which using the legacy JSON-RPC Apis.
+- If the JSON-RPC server doesn't support [new](https://paritytech.github.io/json-rpc-interface-spec/introduction.html) JSON-RPC APIs yet, you can connect using the `LegacyClient` which build on top of the legacy JSON-RPC APIs.
 ```typescript
 import { LegacyClient, WsProvider } from 'dedot';
 

--- a/README.md
+++ b/README.md
@@ -47,12 +47,12 @@ npm i -D @dedot/chaintypes
 - Initialize the API client and start interacting with Polkadot network
 ```typescript
 // main.ts
-import { Dedot, WsProvider } from 'dedot';
+import { DedotClient, WsProvider } from 'dedot';
 import type { PolkadotApi } from '@dedot/chaintypes';
 
 const run = async () => {
   const provider = new WsProvider('wss://rpc.polkadot.io');
-  const api = await Dedot.new<PolkadotApi>(provider);
+  const api = await DedotClient.new<PolkadotApi>(provider);
 
   // Call rpc `state_getMetadata` to fetch raw scale-encoded metadata and decode it.
   const metadata = await api.rpc.state_getMetadata();
@@ -86,10 +86,10 @@ run().catch(console.error);
 
 ```js
 // main.js
-const { Dedot, WsProvider } = require('dedot');
+const { DedotClient, WsProvider } = require('dedot');
 // ...
 const provider = new WsProvider('wss://rpc.polkadot.io');
-const api = await Dedot.new(provider);
+const api = await DedotClient.new(provider);
 ```
 ### Table of contents
 - [Status](#status)
@@ -134,26 +134,27 @@ yarn add -D @dedot/chaintypes
 npm i -D @dedot/chaintypes
 ```
 
-Initialize a `Dedot` instance using the `ChainApi` interface for a target chain to enable types & APIs suggestion/autocompletion for that particular chain:
+Initialize a `DedotClient` instance using the `ChainApi` interface for a target chain to enable types & APIs suggestion/autocompletion for that particular chain:
+
 ```typescript
-import { Dedot, WsProvider } from 'dedot';
+import { DedotClient, WsProvider } from 'dedot';
 import type { PolkadotApi, KusamaApi, MoonbeamApi, AstarApi } from '@dedot/chaintypes';
 
 // ...
 
-const polkadotApi = await Dedot.new<PolkadotApi>(new WsProvider('wss://rpc.polkadot.io'));
+const polkadotApi = await DedotClient.new<PolkadotApi>(new WsProvider('wss://rpc.polkadot.io'));
 console.log(await polkadotApi.query.babe.authorities());
 
-const kusamaApi = await Dedot.new<KusamaApi>(new WsProvider('wss://kusama-rpc.polkadot.io'));
+const kusamaApi = await DedotClient.new<KusamaApi>(new WsProvider('wss://kusama-rpc.polkadot.io'));
 console.log(await kusamaApi.query.society.memberCount());
 
-const moonbeamApi = await Dedot.new<MoonbeamApi>(new WsProvider('wss://wss.api.moonbeam.network'));
+const moonbeamApi = await DedotClient.new<MoonbeamApi>(new WsProvider('wss://wss.api.moonbeam.network'));
 console.log(await moonbeamApi.query.ethereumChainId.chainId());
 
-const astarApi = await Dedot.new<AstarApi>(new WsProvider('wss://rpc.astar.network'));
+const astarApi = await DedotClient.new<AstarApi>(new WsProvider('wss://rpc.astar.network'));
 console.log(await astarApi.query.dappsStaking.blockRewardAccumulator());
 
-const genericApi = await Dedot.new(new WsProvider('ws://localhost:9944'));
+const genericApi = await DedotClient.new(new WsProvider('ws://localhost:9944'));
 
 // ...
 ```
@@ -220,16 +221,16 @@ const queryInfo = await api.call.transactionPaymentApi.queryInfo(tx.toU8a(), tx.
 const runtimeVersion = await api.call.core.version();
 ```
 
-For chains that only support Metadata V14, we need to bring in the Runtime Api definitions when initializing the Dedot client instance to encode & decode the calls. You can find all supported Runtime Api definitions in [`dedot/runtime-specs`](https://github.com/dedotdev/dedot/blob/60de0fed8ba19c67a7e174c6168a127fdbf6caef/packages/runtime-specs/src/runtime/all.ts#L21-L39) package.
+For chains that only support Metadata V14, we need to bring in the Runtime Api definitions when initializing the DedotClient instance to encode & decode the calls. You can find all supported Runtime Api definitions in [`dedot/runtime-specs`](https://github.com/dedotdev/dedot/blob/60de0fed8ba19c67a7e174c6168a127fdbf6caef/packages/runtime-specs/src/runtime/all.ts#L21-L39) package.
 
 Examples:
 ```typescript
 import { RuntimeApis } from 'dedot/runtime-specs';
-const api = await Dedot.new({ provider: new WsProvider('wss://rpc.mynetwork.com'), runtimeApis: RuntimeApis });
+const api = await DedotClient.new({ provider: new WsProvider('wss://rpc.mynetwork.com'), runtimeApis: RuntimeApis });
 
 // Or bring in only the Runtime Api definition that you want to interact with
 import { AccountNonceApi } from 'dedot/runtime-specs';
-const api = await Dedot.new({ provider: new WsProvider('wss://rpc.mynetwork.com'), runtimeApis: { AccountNonceApi } });
+const api = await DedotClient.new({ provider: new WsProvider('wss://rpc.mynetwork.com'), runtimeApis: { AccountNonceApi } });
 
 // Get account nonce
 const nonce = await api.call.accountNonceApi.accountNonce(<address>);
@@ -431,14 +432,15 @@ import { ApiPromise, WsProvider } from '@polkadot/api';
 const api = await ApiPromise.create({ provider: new WsProvider('wss://rpc.polkadot.io') });
 ```
 - `dedot`
+
 ```typescript
-import { Dedot, WsProvider } from 'dedot';
+import { DedotClient, WsProvider } from 'dedot';
 import type { PolkadotApi } from '@dedot/chaintypes';
 
-const api = await Dedot.new<PolkadotApi>(new WsProvider('wss://rpc.polkadot.io')); // or Dedot.create(...) if you prefer
+const api = await DedotClient.new<PolkadotApi>(new WsProvider('wss://rpc.polkadot.io')); // or Dedot.create(...) if you prefer
 
 // OR
-const api = await Dedot.new<PolkadotApi>({ provider: new WsProvider('wss://rpc.polkadot.io') });
+const api = await DedotClient.new<PolkadotApi>({provider: new WsProvider('wss://rpc.polkadot.io')});
 ```
 
 - Notes:

--- a/examples/dapp/src/App.tsx
+++ b/examples/dapp/src/App.tsx
@@ -1,15 +1,15 @@
 import { useState } from 'react';
 import { useAsync } from 'react-use';
-import { Dedot, WsProvider } from 'dedot';
+import { LegacyClient, WsProvider } from 'dedot';
 import './App.css';
 
 const ENDPOINT = 'wss://rpc.polkadot.io';
 
 function App() {
-  const [api, setApi] = useState<Dedot>();
+  const [api, setApi] = useState<LegacyClient>();
   useAsync(async () => {
     console.time('init api took');
-    setApi(await Dedot.new({ provider: new WsProvider(ENDPOINT), cacheMetadata: true }));
+    setApi(await LegacyClient.new({ provider: new WsProvider(ENDPOINT), cacheMetadata: true }));
     console.timeEnd('init api took');
   });
 

--- a/packages/api/src/client/LegacyClient.ts
+++ b/packages/api/src/client/LegacyClient.ts
@@ -17,7 +17,7 @@ import { BaseSubstrateClient } from './BaseSubstrateClient.js';
 const KEEP_ALIVE_INTERVAL = 10_000; // in ms
 
 /**
- * @name Dedot
+ * @name LegacyClient
  * @description Promised-based API Client for Polkadot & Substrate
  *
  * Initialize API instance and interact with substrate-based network
@@ -54,7 +54,9 @@ const KEEP_ALIVE_INTERVAL = 10_000; // in ms
  * run().catch(console.error);
  * ```
  */
-export class Dedot<ChainApi extends VersionedGenericSubstrateApi = SubstrateApi> extends BaseSubstrateClient<ChainApi> {
+export class LegacyClient<
+  ChainApi extends VersionedGenericSubstrateApi = SubstrateApi,
+> extends BaseSubstrateClient<ChainApi> {
   #runtimeSubscriptionUnsub?: Unsub;
   #healthTimer?: ReturnType<typeof setInterval>;
   #apiAtCache: Record<BlockHash, ISubstrateClientAt<any>> = {};
@@ -75,8 +77,8 @@ export class Dedot<ChainApi extends VersionedGenericSubstrateApi = SubstrateApi>
    */
   static async create<ChainApi extends VersionedGenericSubstrateApi = SubstrateApi>(
     options: ApiOptions | JsonRpcProvider,
-  ): Promise<Dedot<ChainApi>> {
-    return new Dedot<ChainApi>(options).connect();
+  ): Promise<LegacyClient<ChainApi>> {
+    return new LegacyClient<ChainApi>(options).connect();
   }
 
   /**
@@ -86,8 +88,8 @@ export class Dedot<ChainApi extends VersionedGenericSubstrateApi = SubstrateApi>
    */
   static async new<ChainApi extends VersionedGenericSubstrateApi = SubstrateApi>(
     options: ApiOptions | JsonRpcProvider,
-  ): Promise<Dedot<ChainApi>> {
-    return Dedot.create(options);
+  ): Promise<LegacyClient<ChainApi>> {
+    return LegacyClient.create(options);
   }
 
   protected override onDisconnected = async () => {

--- a/packages/api/src/client/__tests__/LegacyClient.spec.ts
+++ b/packages/api/src/client/__tests__/LegacyClient.spec.ts
@@ -4,23 +4,23 @@ import type { AnyShape } from '@dedot/shape';
 import * as $ from '@dedot/shape';
 import { stringCamelCase, stringPascalCase, u8aToHex } from '@dedot/utils';
 import { afterEach, beforeEach, describe, expect, expectTypeOf, it, vi } from 'vitest';
-import { Dedot } from '../Dedot.js';
+import { LegacyClient } from '../LegacyClient.js';
 import MockProvider, { MockedRuntimeVersion } from './MockProvider.js';
 
-describe('Dedot', () => {
+describe('LegacyClient', () => {
   it('should throws error for invalid endpoint', () => {
     expect(async () => {
-      await Dedot.new(new WsProvider('invalid_endpoint'));
+      await LegacyClient.new(new WsProvider('invalid_endpoint'));
     }).rejects.toThrowError(
       'Invalid websocket endpoint invalid_endpoint, a valid endpoint should start with wss:// or ws://',
     );
   });
 
   describe('cache disabled', () => {
-    let api: Dedot, provider: MockProvider;
+    let api: LegacyClient, provider: MockProvider;
     beforeEach(async () => {
       provider = new MockProvider();
-      api = await Dedot.new({ provider });
+      api = await LegacyClient.new({ provider });
     });
 
     afterEach(async () => {
@@ -197,7 +197,7 @@ describe('Dedot', () => {
           tryEncode: vi.fn(() => new Uint8Array()),
         };
 
-        api = await Dedot.create({
+        api = await LegacyClient.create({
           provider: new MockProvider(),
           runtimeApis: {
             Metadata: [
@@ -314,9 +314,9 @@ describe('Dedot', () => {
   });
 
   describe('cache enabled', () => {
-    let api: Dedot;
+    let api: LegacyClient;
     beforeEach(async () => {
-      api = await Dedot.new({ provider: new MockProvider(), cacheMetadata: true });
+      api = await LegacyClient.new({ provider: new MockProvider(), cacheMetadata: true });
     });
 
     afterEach(async () => {
@@ -329,7 +329,7 @@ describe('Dedot', () => {
     it('should load metadata from cache', async () => {
       const provider = new MockProvider();
       const providerSendSpy = vi.spyOn(provider, 'send');
-      const newApi = await Dedot.new({ provider, cacheMetadata: true });
+      const newApi = await LegacyClient.new({ provider, cacheMetadata: true });
 
       expect(providerSendSpy).not.toBeCalledWith('state_getMetadata', []);
       expect(newApi.metadata).toBeDefined();
@@ -345,7 +345,7 @@ describe('Dedot', () => {
       );
 
       const providerSendSpy = vi.spyOn(provider, 'send');
-      const newApi = await Dedot.new({ provider, cacheMetadata: true });
+      const newApi = await LegacyClient.new({ provider, cacheMetadata: true });
 
       expect(providerSendSpy).toBeCalledWith('state_getMetadata', []);
       expect(newApi.metadata).toBeDefined();
@@ -356,9 +356,9 @@ describe('Dedot', () => {
   });
 
   describe('not throwOnUnknownApi', () => {
-    let api: Dedot;
+    let api: LegacyClient;
     beforeEach(async () => {
-      api = await Dedot.new({ provider: new MockProvider(), throwOnUnknownApi: false });
+      api = await LegacyClient.new({ provider: new MockProvider(), throwOnUnknownApi: false });
     });
 
     afterEach(async () => {

--- a/packages/api/src/client/index.ts
+++ b/packages/api/src/client/index.ts
@@ -1,2 +1,2 @@
-export * from './Dedot.js';
+export * from './LegacyClient.js';
 export * from './DedotClient.js';

--- a/packages/codegen/src/index.ts
+++ b/packages/codegen/src/index.ts
@@ -1,4 +1,4 @@
-import { Dedot } from '@dedot/api';
+import { LegacyClient } from '@dedot/api';
 import { MetadataLatest } from '@dedot/codecs';
 import { WsProvider } from '@dedot/providers';
 import { RpcMethods } from '@dedot/types/json-rpc';
@@ -24,7 +24,7 @@ export async function generateTypesFromEndpoint(
   extension: string = 'd.ts',
   useSubPaths: boolean = false,
 ) {
-  const api = await Dedot.new(new WsProvider(endpoint));
+  const api = await LegacyClient.new(new WsProvider(endpoint));
   const { methods }: RpcMethods = await api.rpc.rpc_methods();
   const apis = api.runtimeVersion.apis || {};
   if (!chain) {

--- a/packages/contracts/src/__tests__/Contract.spec.ts
+++ b/packages/contracts/src/__tests__/Contract.spec.ts
@@ -1,4 +1,4 @@
-import { Dedot, FallbackRuntimeApis } from '@dedot/api';
+import { LegacyClient, FallbackRuntimeApis } from '@dedot/api';
 import MockProvider from '@dedot/api/client/__tests__/MockProvider';
 import { RuntimeVersion } from '@dedot/codecs';
 import { beforeEach, describe, expect, it } from 'vitest';
@@ -22,12 +22,12 @@ export const MockedRuntimeVersionWithContractsApi: RuntimeVersion = {
 };
 
 describe('Contract', () => {
-  let api: Dedot, provider: MockProvider, flipper: Contract, psp22: Contract;
+  let api: LegacyClient, provider: MockProvider, flipper: Contract, psp22: Contract;
 
   describe('api support contracts pallet', () => {
     beforeEach(async () => {
       provider = new MockProvider(MockedRuntimeVersionWithContractsApi);
-      api = await Dedot.new({ provider });
+      api = await LegacyClient.new({ provider });
       flipper = new Contract(api, RANDOM_CONTRACT_ADDRESS, FLIPPER_CONTRACT_METADATA);
       psp22 = new Contract(api, RANDOM_CONTRACT_ADDRESS, PSP22_CONTRACT_METADATA);
     });
@@ -72,7 +72,7 @@ describe('Contract', () => {
   describe('api not support contracts pallet', () => {
     it('should throw error', async () => {
       provider = new MockProvider();
-      api = await Dedot.new({ provider });
+      api = await LegacyClient.new({ provider });
       expect(() => new Contract(api, RANDOM_CONTRACT_ADDRESS, FLIPPER_CONTRACT_METADATA)).toThrowError(
         'Contracts pallet is not available',
       );

--- a/packages/contracts/src/__tests__/ContractDeployer.spec.ts
+++ b/packages/contracts/src/__tests__/ContractDeployer.spec.ts
@@ -1,4 +1,4 @@
-import { Dedot } from '@dedot/api';
+import { LegacyClient } from '@dedot/api';
 import MockProvider from '@dedot/api/client/__tests__/MockProvider';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { ContractDeployer } from '../ContractDeployer.js';
@@ -6,12 +6,12 @@ import { MockedRuntimeVersionWithContractsApi } from './Contract.spec.js';
 import { FLIPPER_CONTRACT_METADATA, PSP22_CONTRACT_METADATA } from './contracts-metadata.js';
 
 describe('ContractDeployer', () => {
-  let api: Dedot, provider: MockProvider, flipper: ContractDeployer, psp22: ContractDeployer;
+  let api: LegacyClient, provider: MockProvider, flipper: ContractDeployer, psp22: ContractDeployer;
 
   describe('api support contracts pallet', () => {
     beforeEach(async () => {
       provider = new MockProvider(MockedRuntimeVersionWithContractsApi);
-      api = await Dedot.new({ provider });
+      api = await LegacyClient.new({ provider });
       flipper = new ContractDeployer(api, FLIPPER_CONTRACT_METADATA, FLIPPER_CONTRACT_METADATA.source.hash);
       psp22 = new ContractDeployer(api, PSP22_CONTRACT_METADATA, PSP22_CONTRACT_METADATA.source.hash);
     });
@@ -32,7 +32,7 @@ describe('ContractDeployer', () => {
   describe('api not support contracts pallet', () => {
     it('should throw error', async () => {
       provider = new MockProvider();
-      api = await Dedot.new({ provider });
+      api = await LegacyClient.new({ provider });
       expect(
         () => new ContractDeployer(api, FLIPPER_CONTRACT_METADATA, FLIPPER_CONTRACT_METADATA.source.hash),
       ).toThrowError('Contracts pallet is not available');

--- a/zombienet-tests/src/0001-check-contract-api.ts
+++ b/zombienet-tests/src/0001-check-contract-api.ts
@@ -1,6 +1,6 @@
 import Keyring from '@polkadot/keyring';
 import { cryptoWaitReady } from '@polkadot/util-crypto';
-import { Dedot, DedotClient, ISubstrateClient, WsProvider } from 'dedot';
+import { LegacyClient, DedotClient, ISubstrateClient, WsProvider } from 'dedot';
 import { Contract, ContractDeployer } from 'dedot/contracts';
 import { assert, stringToHex } from 'dedot/utils';
 import * as flipperRaw from '../flipper.json';
@@ -71,7 +71,7 @@ export const run = async (_nodeName: any, networkInfo: any) => {
   };
 
   console.log('Checking via legacy API');
-  const apiLegacy = await Dedot.new(new WsProvider(wsUri));
+  const apiLegacy = await LegacyClient.new(new WsProvider(wsUri));
   await verifyContracts(apiLegacy);
 
   console.log('Checking via new API');

--- a/zombienet-tests/src/0001-check-payment-info.ts
+++ b/zombienet-tests/src/0001-check-payment-info.ts
@@ -1,4 +1,4 @@
-import { Dedot, DedotClient, ISubstrateClient, WsProvider } from 'dedot';
+import { LegacyClient, DedotClient, ISubstrateClient, WsProvider } from 'dedot';
 import { SubstrateApi } from 'dedot/chaintypes';
 import { RpcVersion, TxPaymentInfo } from 'dedot/types';
 import { assert } from 'dedot/utils';
@@ -13,7 +13,7 @@ export const run = async (nodeName: any, networkInfo: any) => {
     return api.tx.balances.transferKeepAlive(ALICE, BigInt(10 * 1e12)).paymentInfo(BOB);
   };
 
-  const apiV1 = await Dedot.new(new WsProvider(wsUri));
+  const apiV1 = await LegacyClient.new(new WsProvider(wsUri));
   const paymentInfoV1 = await getPaymentInfo(apiV1);
 
   console.log('[API-V1] Payment Info', paymentInfoV1);

--- a/zombienet-tests/src/0001-check-runtime-api.ts
+++ b/zombienet-tests/src/0001-check-runtime-api.ts
@@ -1,4 +1,4 @@
-import { Dedot, DedotClient, ISubstrateClient, WsProvider } from 'dedot';
+import { LegacyClient, DedotClient, ISubstrateClient, WsProvider } from 'dedot';
 import { SubstrateApi } from 'dedot/chaintypes';
 import { $Metadata, Metadata } from 'dedot/codecs';
 import { RpcVersion } from 'dedot/types';
@@ -42,7 +42,7 @@ const verifyRuntimeApi = async (api: ISubstrateClient<SubstrateApi[RpcVersion]>)
 export const run = async (nodeName: any, networkInfo: any) => {
   const { wsUri } = networkInfo.nodesByName[nodeName];
 
-  const apiLegacy = await Dedot.new(new WsProvider(wsUri));
+  const apiLegacy = await LegacyClient.new(new WsProvider(wsUri));
   await verifyRuntimeApi(apiLegacy);
 
   const apiV2 = await DedotClient.new(new WsProvider(wsUri));

--- a/zombienet-tests/src/0001-check-storage-map-pagination.ts
+++ b/zombienet-tests/src/0001-check-storage-map-pagination.ts
@@ -1,4 +1,4 @@
-import { Dedot, WsProvider } from 'dedot';
+import { LegacyClient, WsProvider } from 'dedot';
 import { assert } from 'dedot/utils';
 
 // @ts-ignore
@@ -9,7 +9,7 @@ BigInt.prototype.toJSON = function () {
 export const run = async (nodeName: any, networkInfo: any) => {
   const { wsUri } = networkInfo.nodesByName[nodeName];
 
-  const api = await Dedot.new(new WsProvider(wsUri));
+  const api = await LegacyClient.new(new WsProvider(wsUri));
 
   // Verify pagedKeys
   const firstBatch = await api.query.system.account.pagedKeys({ pageSize: 2 });

--- a/zombienet-tests/src/0001-check-storage-query.ts
+++ b/zombienet-tests/src/0001-check-storage-query.ts
@@ -1,4 +1,4 @@
-import { Dedot, WsProvider } from 'dedot';
+import { LegacyClient, WsProvider } from 'dedot';
 import { assert } from 'dedot/utils';
 
 const ALICE = '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY';
@@ -9,7 +9,7 @@ const addressesToCheck: Record<string, string> = { ALICE, BOB };
 export const run = async (nodeName: any, networkInfo: any) => {
   const { wsUri } = networkInfo.nodesByName[nodeName];
 
-  const api = await Dedot.new(new WsProvider(wsUri));
+  const api = await LegacyClient.new(new WsProvider(wsUri));
 
   const balances = await api.query.system.account.multi([ALICE, BOB]);
 

--- a/zombienet-tests/src/0001-check-tx-batch.ts
+++ b/zombienet-tests/src/0001-check-tx-batch.ts
@@ -1,7 +1,7 @@
 import Keyring from '@polkadot/keyring';
 import { cryptoWaitReady } from '@polkadot/util-crypto';
 import { RococoRuntimeRuntimeCallLike } from '@dedot/chaintypes/rococo';
-import { Dedot, WsProvider } from 'dedot';
+import { LegacyClient, WsProvider } from 'dedot';
 import { assert } from 'dedot/utils';
 
 const BOB = '5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty';
@@ -14,7 +14,7 @@ export const run = async (nodeName: any, networkInfo: any): Promise<void> => {
   const { wsUri } = networkInfo.nodesByName[nodeName];
 
   // TODO use RococoApi
-  const api = await Dedot.new(new WsProvider(wsUri));
+  const api = await LegacyClient.new(new WsProvider(wsUri));
 
   const TEN_UNIT = BigInt(10 * 1e12);
 

--- a/zombienet-tests/src/0001-check-tx-transfer-balance.ts
+++ b/zombienet-tests/src/0001-check-tx-transfer-balance.ts
@@ -1,6 +1,6 @@
 import Keyring from '@polkadot/keyring';
 import { cryptoWaitReady } from '@polkadot/util-crypto';
-import { Dedot, WsProvider } from 'dedot';
+import { LegacyClient, WsProvider } from 'dedot';
 import { assert } from 'dedot/utils';
 
 const BOB = '5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty';
@@ -13,7 +13,7 @@ export const run = async (nodeName: any, networkInfo: any): Promise<void> => {
   const { wsUri } = networkInfo.nodesByName[nodeName];
 
   // TODO use RococoApi
-  const api = await Dedot.new(new WsProvider(wsUri));
+  const api = await LegacyClient.new(new WsProvider(wsUri));
 
   const prevBobBalance = (await api.query.system.account(BOB)).data.free;
   const prevBlockNumber = await api.query.system.number();

--- a/zombienet-tests/src/0001-tx-broadcaster.ts
+++ b/zombienet-tests/src/0001-tx-broadcaster.ts
@@ -1,9 +1,9 @@
 import Keyring from '@polkadot/keyring';
 import { cryptoWaitReady } from '@polkadot/util-crypto';
-import { Dedot, Transaction, TransactionWatch, TxBroadcaster, WsProvider } from 'dedot';
+import { LegacyClient, Transaction, TransactionWatch, TxBroadcaster, WsProvider } from 'dedot';
 import { deferred, HexString, stringToHex } from 'dedot/utils';
 
-const prepareRemarkTx = async (api: Dedot): Promise<{ rawTx: HexString; sender: string }> => {
+const prepareRemarkTx = async (api: LegacyClient): Promise<{ rawTx: HexString; sender: string }> => {
   await cryptoWaitReady();
   const keyring = new Keyring({ type: 'sr25519' });
   const alice = keyring.addFromUri('//Alice');
@@ -20,7 +20,7 @@ const prepareRemarkTx = async (api: Dedot): Promise<{ rawTx: HexString; sender: 
 export const run = async (nodeName: any, networkInfo: any): Promise<any> => {
   const { wsUri } = networkInfo.nodesByName[nodeName];
 
-  const api = await Dedot.new(new WsProvider(wsUri));
+  const api = await LegacyClient.new(new WsProvider(wsUri));
 
   const broadcastUntilRemark = async (txBroadcaster: TxBroadcaster) => {
     const defer = deferred<void>();


### PR DESCRIPTION
Rename the legacy client from `Dedot` to `LegacyClient`.

The new client `DedotClient` built on top of the new JsonRpc is recommended to use. Users can also still use the `LegacyClient` as well if the JSON RPC server does not support new spec.