### PR TITLE
chore: revert zombienet versions

### DIFF
--- a/.github/workflows/zombienet-tests.yml
+++ b/.github/workflows/zombienet-tests.yml
@@ -25,19 +25,19 @@ jobs:
       - run: yarn zombienet-test-preps
       - name: Download executables
         run: |
-          curl -L -O https://github.com/paritytech/zombienet/releases/download/v1.3.106/zombienet-linux-x64
+          curl -L -O https://github.com/paritytech/zombienet/releases/download/v1.3.102/zombienet-linux-x64
           chmod +x zombienet-linux-x64
           
-          curl -L -O https://github.com/paritytech/polkadot-sdk/releases/download/polkadot-v1.13.0/polkadot
+          curl -L -O https://github.com/paritytech/polkadot-sdk/releases/download/polkadot-v1.7.0/polkadot
           chmod +x polkadot
           
-          curl -L -O https://github.com/paritytech/polkadot-sdk/releases/download/polkadot-v1.13.0/polkadot-execute-worker
+          curl -L -O https://github.com/paritytech/polkadot-sdk/releases/download/polkadot-v1.7.0/polkadot-execute-worker
           chmod +x polkadot-execute-worker
           
-          curl -L -O https://github.com/paritytech/polkadot-sdk/releases/download/polkadot-v1.13.0/polkadot-prepare-worker
+          curl -L -O https://github.com/paritytech/polkadot-sdk/releases/download/polkadot-v1.7.0/polkadot-prepare-worker
           chmod +x polkadot-prepare-worker
           
-          curl -L -O https://github.com/paritytech/polkadot-sdk/releases/download/polkadot-v1.13.0/polkadot-parachain
+          curl -L -O https://github.com/paritytech/polkadot-sdk/releases/download/polkadot-v1.7.0/polkadot-parachain
           chmod +x polkadot-parachain
       - name: Run tests on small network
         run: |

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ A delightful JavaScript/TypeScript client for [Polkadot](https://polkadot.networ
 <p align="left">
   <img src="https://img.shields.io/github/license/dedotdev/dedot?style=flat-square"/>
   <img src="https://img.shields.io/github/actions/workflow/status/dedotdev/dedot/run-tests.yml?label=unit%20tests&style=flat-square"/>
+  <img src="https://img.shields.io/github/actions/workflow/status/dedotdev/dedot/zombienet-tests.yml?label=e2e%20tests&style=flat-square"/>
   <img src="https://img.shields.io/github/package-json/v/dedotdev/dedot?filename=packages%2Fapi%2Fpackage.json&style=flat-square"/>
 </p>
 


### PR DESCRIPTION
New zombienet executable versions causing some inconsistency in executing e2e tests, for now let's revert it back to the previous version. We'll investigate the root cause of the inconsistency and going back later.