### PR TITLE
breaking: TransactionEvent -> TxStatus

### DIFF
--- a/packages/api/src/chaintypes/substrate/tx.ts
+++ b/packages/api/src/chaintypes/substrate/tx.ts
@@ -23,7 +23,7 @@ import type {
   ISubmittableResult,
   RpcV2,
   RpcVersion,
-  TransactionEvent,
+  TxStatus,
 } from '@dedot/types';
 import type {
   FrameSupportPreimagesBounded,
@@ -113,8 +113,8 @@ export type ChainSubmittableExtrinsic<
   T extends IRuntimeTxCall = KitchensinkRuntimeRuntimeCallLike,
 > = Extrinsic<MultiAddressLike, T, SpRuntimeMultiSignature, any[]> &
   (Rv extends RpcV2
-    ? ISubmittableExtrinsic<ISubmittableResult<FrameSystemEventRecord, TransactionEvent>>
-    : ISubmittableExtrinsicLegacy<ISubmittableResult<FrameSystemEventRecord, TransactionEvent>>);
+    ? ISubmittableExtrinsic<ISubmittableResult<FrameSystemEventRecord, TxStatus>>
+    : ISubmittableExtrinsicLegacy<ISubmittableResult<FrameSystemEventRecord, TxStatus>>);
 
 export type TxCall<Rv extends RpcVersion> = (...args: any[]) => ChainSubmittableExtrinsic<Rv>;
 

--- a/packages/api/src/extrinsic/submittable/SubmittableExtrinsic.ts
+++ b/packages/api/src/extrinsic/submittable/SubmittableExtrinsic.ts
@@ -11,7 +11,7 @@ import {
 import { assert, isHex } from '@dedot/utils';
 import { BaseSubmittableExtrinsic } from './BaseSubmittableExtrinsic.js';
 import { SubmittableResult } from './SubmittableResult.js';
-import { toTransactionEvent } from './utils.js';
+import { toTxStatus } from './utils.js';
 
 /**
  * @name SubmittableExtrinsic
@@ -51,10 +51,10 @@ export class SubmittableExtrinsic extends BaseSubmittableExtrinsic implements IS
 
           const events = blockEvents.filter(({ phase }) => phase.type === 'ApplyExtrinsic' && phase.value === txIndex);
 
-          const status = toTransactionEvent(txStatus, txIndex);
+          const status = toTxStatus(txStatus, txIndex);
           return callback(new SubmittableResult({ status, txHash, events, txIndex }));
         } else {
-          const status = toTransactionEvent(txStatus);
+          const status = toTxStatus(txStatus);
           return callback(new SubmittableResult({ status, txHash }));
         }
       });

--- a/packages/api/src/extrinsic/submittable/SubmittableExtrinsicV2.ts
+++ b/packages/api/src/extrinsic/submittable/SubmittableExtrinsicV2.ts
@@ -1,5 +1,5 @@
 import type { BlockHash, Hash } from '@dedot/codecs';
-import type { Callback, IEventRecord, IRuntimeTxCall, ISubmittableResult, TransactionEvent, Unsub } from '@dedot/types';
+import type { Callback, IEventRecord, IRuntimeTxCall, ISubmittableResult, TxStatus, Unsub } from '@dedot/types';
 import { AsyncQueue, deferred, noop } from '@dedot/utils';
 import { DedotClient } from '../../client/index.js';
 import { PinnedBlock } from '../../json-rpc/index.js';
@@ -21,7 +21,7 @@ export class SubmittableExtrinsicV2 extends BaseSubmittableExtrinsic {
     super(api, call);
   }
 
-  async #send(callback: Callback<ISubmittableResult<IEventRecord, TransactionEvent>>): Promise<Unsub> {
+  async #send(callback: Callback<ISubmittableResult<IEventRecord, TxStatus>>): Promise<Unsub> {
     const api = this.api;
     const txHex = this.toHex();
     const txHash = this.hash;
@@ -105,7 +105,7 @@ export class SubmittableExtrinsicV2 extends BaseSubmittableExtrinsic {
           if (txFound && bestChainChanged) {
             txFound = undefined;
             callback(
-              new SubmittableResult<IEventRecord, TransactionEvent>({
+              new SubmittableResult<IEventRecord, TxStatus>({
                 status: { type: 'NoLongerInBestChain' },
                 txHash,
               }),
@@ -124,7 +124,7 @@ export class SubmittableExtrinsicV2 extends BaseSubmittableExtrinsic {
         const { index: txIndex, events, blockHash } = inBlock;
 
         callback(
-          new SubmittableResult<IEventRecord, TransactionEvent>({
+          new SubmittableResult<IEventRecord, TxStatus>({
             status: { type: 'BestChainBlockIncluded', value: { blockHash, txIndex } },
             txHash,
             events,
@@ -160,7 +160,7 @@ export class SubmittableExtrinsicV2 extends BaseSubmittableExtrinsic {
         const { index: txIndex, events, blockHash } = inBlock;
 
         callback(
-          new SubmittableResult<IEventRecord, TransactionEvent>({
+          new SubmittableResult<IEventRecord, TxStatus>({
             status: { type: 'Finalized', value: { blockHash, txIndex } },
             txHash,
             events,
@@ -174,7 +174,7 @@ export class SubmittableExtrinsicV2 extends BaseSubmittableExtrinsic {
         if (validation.isOk) return;
 
         callback(
-          new SubmittableResult<IEventRecord, TransactionEvent>({
+          new SubmittableResult<IEventRecord, TxStatus>({
             status: {
               type: 'Invalid',
               value: { error: `Invalid Tx: ${validation.err.type} - ${validation.err.value.type}` },
@@ -189,7 +189,7 @@ export class SubmittableExtrinsicV2 extends BaseSubmittableExtrinsic {
 
     stopBroadcastFn = await api.txBroadcaster.broadcastTx(txHex);
     callback(
-      new SubmittableResult<IEventRecord, TransactionEvent>({
+      new SubmittableResult<IEventRecord, TxStatus>({
         status: { type: 'Broadcasting' },
         txHash,
       }),

--- a/packages/api/src/extrinsic/submittable/utils.ts
+++ b/packages/api/src/extrinsic/submittable/utils.ts
@@ -1,6 +1,6 @@
 import { IKeyringPair } from '@polkadot/types/types';
 import { TransactionStatus } from '@dedot/codecs';
-import type { AddressOrPair, TransactionEvent } from '@dedot/types';
+import type { AddressOrPair, TxStatus } from '@dedot/types';
 import { assert, blake2AsU8a, HexString, hexToU8a, isFunction } from '@dedot/utils';
 
 export function isKeyringPair(account: AddressOrPair): account is IKeyringPair {
@@ -27,7 +27,7 @@ export function signRaw(signerPair: IKeyringPair, raw: HexString): Uint8Array {
  * @param txStatus
  * @param txIndex
  */
-export function toTransactionEvent(txStatus: TransactionStatus, txIndex?: number): TransactionEvent {
+export function toTxStatus(txStatus: TransactionStatus, txIndex?: number): TxStatus {
   switch (txStatus.type) {
     case 'Ready':
     case 'Future':

--- a/packages/codegen/src/chaintypes/generator/TxGen.ts
+++ b/packages/codegen/src/chaintypes/generator/TxGen.ts
@@ -16,7 +16,7 @@ export class TxGen extends ApiGen {
       'RpcVersion',
       'RpcV2',
       'ISubmittableExtrinsicLegacy',
-      'TransactionEvent',
+      'TxStatus',
     );
 
     const { callTypeId, addressTypeId, signatureTypeId } = this.metadata.extrinsic;
@@ -85,8 +85,8 @@ export class TxGen extends ApiGen {
     export type ChainSubmittableExtrinsic<Rv extends RpcVersion, T extends IRuntimeTxCall = ${callTypeIn}> = 
         Extrinsic<${addressTypeIn}, T, ${signatureTypeIn}, any[]> &
         (Rv extends RpcV2
-          ? ISubmittableExtrinsic<ISubmittableResult<FrameSystemEventRecord, TransactionEvent>>
-          : ISubmittableExtrinsicLegacy<ISubmittableResult<FrameSystemEventRecord, TransactionEvent>>)
+          ? ISubmittableExtrinsic<ISubmittableResult<FrameSystemEventRecord, TxStatus>>
+          : ISubmittableExtrinsicLegacy<ISubmittableResult<FrameSystemEventRecord, TxStatus>>)
         
     export type TxCall<Rv extends RpcVersion> = (...args: any[]) => ChainSubmittableExtrinsic<Rv>;    
 `;

--- a/packages/types/src/extrinsic.ts
+++ b/packages/types/src/extrinsic.ts
@@ -1,13 +1,5 @@
 import { IKeyringPair, Signer } from '@polkadot/types/types';
-import {
-  ApplyExtrinsicResult,
-  BlockHash,
-  DispatchError,
-  DispatchInfo,
-  Hash,
-  RuntimeDispatchInfo,
-  TransactionStatus,
-} from '@dedot/codecs';
+import { ApplyExtrinsicResult, BlockHash, DispatchError, DispatchInfo, Hash, RuntimeDispatchInfo } from '@dedot/codecs';
 import { HexString } from '@dedot/utils';
 import { Callback, IEventRecord, Unsub } from './index.js';
 
@@ -74,7 +66,7 @@ export interface ISubmittableExtrinsicLegacy<R extends ISubmittableResult = ISub
 }
 
 // We want to mimic an enum type for the new transaction status
-export type TransactionEvent =
+export type TxStatus =
   | { type: 'Validated' } // emits after we validate the transaction via `call.taggedTransactionQueue.validateTransaction`
   | { type: 'Broadcasting' } // emits after we submit the transaction via TxBroadcaster
   | { type: 'BestChainBlockIncluded'; value: { blockHash: HexString; txIndex: number } }


### PR DESCRIPTION
I find it a bit weird using the name `TransactionEvent` while we still using the field `status` in `ISubmittableResult` for this type. So I decided to go with `TxStatus` since `TransactionStatus` are already exist to prevent people confusing if there're 2 types with the same name or so.