### PR TITLE
fix: remove generic over TxStatus

### DIFF
--- a/packages/api/src/chaintypes/substrate/tx.ts
+++ b/packages/api/src/chaintypes/substrate/tx.ts
@@ -23,7 +23,6 @@ import type {
   ISubmittableResult,
   RpcV2,
   RpcVersion,
-  TxStatus,
 } from '@dedot/types';
 import type {
   FrameSupportPreimagesBounded,
@@ -113,8 +112,8 @@ export type ChainSubmittableExtrinsic<
   T extends IRuntimeTxCall = KitchensinkRuntimeRuntimeCallLike,
 > = Extrinsic<MultiAddressLike, T, SpRuntimeMultiSignature, any[]> &
   (Rv extends RpcV2
-    ? ISubmittableExtrinsic<ISubmittableResult<FrameSystemEventRecord, TxStatus>>
-    : ISubmittableExtrinsicLegacy<ISubmittableResult<FrameSystemEventRecord, TxStatus>>);
+    ? ISubmittableExtrinsic<ISubmittableResult<FrameSystemEventRecord>>
+    : ISubmittableExtrinsicLegacy<ISubmittableResult<FrameSystemEventRecord>>);
 
 export type TxCall<Rv extends RpcVersion> = (...args: any[]) => ChainSubmittableExtrinsic<Rv>;
 

--- a/packages/api/src/extrinsic/submittable/SubmittableExtrinsicV2.ts
+++ b/packages/api/src/extrinsic/submittable/SubmittableExtrinsicV2.ts
@@ -21,7 +21,7 @@ export class SubmittableExtrinsicV2 extends BaseSubmittableExtrinsic {
     super(api, call);
   }
 
-  async #send(callback: Callback<ISubmittableResult<IEventRecord, TxStatus>>): Promise<Unsub> {
+  async #send(callback: Callback<ISubmittableResult>): Promise<Unsub> {
     const api = this.api;
     const txHex = this.toHex();
     const txHash = this.hash;
@@ -105,7 +105,7 @@ export class SubmittableExtrinsicV2 extends BaseSubmittableExtrinsic {
           if (txFound && bestChainChanged) {
             txFound = undefined;
             callback(
-              new SubmittableResult<IEventRecord, TxStatus>({
+              new SubmittableResult<IEventRecord>({
                 status: { type: 'NoLongerInBestChain' },
                 txHash,
               }),
@@ -124,7 +124,7 @@ export class SubmittableExtrinsicV2 extends BaseSubmittableExtrinsic {
         const { index: txIndex, events, blockHash } = inBlock;
 
         callback(
-          new SubmittableResult<IEventRecord, TxStatus>({
+          new SubmittableResult<IEventRecord>({
             status: { type: 'BestChainBlockIncluded', value: { blockHash, txIndex } },
             txHash,
             events,
@@ -160,7 +160,7 @@ export class SubmittableExtrinsicV2 extends BaseSubmittableExtrinsic {
         const { index: txIndex, events, blockHash } = inBlock;
 
         callback(
-          new SubmittableResult<IEventRecord, TxStatus>({
+          new SubmittableResult<IEventRecord>({
             status: { type: 'Finalized', value: { blockHash, txIndex } },
             txHash,
             events,
@@ -174,7 +174,7 @@ export class SubmittableExtrinsicV2 extends BaseSubmittableExtrinsic {
         if (validation.isOk) return;
 
         callback(
-          new SubmittableResult<IEventRecord, TxStatus>({
+          new SubmittableResult<IEventRecord>({
             status: {
               type: 'Invalid',
               value: { error: `Invalid Tx: ${validation.err.type} - ${validation.err.value.type}` },
@@ -189,7 +189,7 @@ export class SubmittableExtrinsicV2 extends BaseSubmittableExtrinsic {
 
     stopBroadcastFn = await api.txBroadcaster.broadcastTx(txHex);
     callback(
-      new SubmittableResult<IEventRecord, TxStatus>({
+      new SubmittableResult<IEventRecord>({
         status: { type: 'Broadcasting' },
         txHash,
       }),

--- a/packages/api/src/extrinsic/submittable/SubmittableResult.ts
+++ b/packages/api/src/extrinsic/submittable/SubmittableResult.ts
@@ -1,17 +1,15 @@
 import type { DispatchError, DispatchInfo, Hash } from '@dedot/codecs';
-import type { IEventRecord, ISubmittableResult } from '@dedot/types';
+import type { IEventRecord, ISubmittableResult, TxStatus } from '@dedot/types';
 import type { FrameSystemEventRecord } from '../../chaintypes/index.js';
 
-export interface SubmittableResultInputs<E extends IEventRecord = FrameSystemEventRecord, TxStatus extends any = any> {
+export interface SubmittableResultInputs<E extends IEventRecord = FrameSystemEventRecord> {
   events?: E[];
   status: TxStatus;
   txHash: Hash;
   txIndex?: number;
 }
 
-export class SubmittableResult<E extends IEventRecord = FrameSystemEventRecord, TxStatus extends any = any>
-  implements ISubmittableResult<E, TxStatus>
-{
+export class SubmittableResult<E extends IEventRecord = FrameSystemEventRecord> implements ISubmittableResult<E> {
   status: TxStatus;
   events: E[];
   dispatchInfo?: DispatchInfo;
@@ -19,7 +17,7 @@ export class SubmittableResult<E extends IEventRecord = FrameSystemEventRecord, 
   txHash: Hash;
   txIndex?: number;
 
-  constructor({ events, status, txHash, txIndex }: SubmittableResultInputs<E, TxStatus>) {
+  constructor({ events, status, txHash, txIndex }: SubmittableResultInputs<E>) {
     this.events = events || [];
     this.status = status;
     this.txHash = txHash;

--- a/packages/codegen/src/chaintypes/generator/TxGen.ts
+++ b/packages/codegen/src/chaintypes/generator/TxGen.ts
@@ -16,7 +16,6 @@ export class TxGen extends ApiGen {
       'RpcVersion',
       'RpcV2',
       'ISubmittableExtrinsicLegacy',
-      'TxStatus',
     );
 
     const { callTypeId, addressTypeId, signatureTypeId } = this.metadata.extrinsic;
@@ -85,8 +84,8 @@ export class TxGen extends ApiGen {
     export type ChainSubmittableExtrinsic<Rv extends RpcVersion, T extends IRuntimeTxCall = ${callTypeIn}> = 
         Extrinsic<${addressTypeIn}, T, ${signatureTypeIn}, any[]> &
         (Rv extends RpcV2
-          ? ISubmittableExtrinsic<ISubmittableResult<FrameSystemEventRecord, TxStatus>>
-          : ISubmittableExtrinsicLegacy<ISubmittableResult<FrameSystemEventRecord, TxStatus>>)
+          ? ISubmittableExtrinsic<ISubmittableResult<FrameSystemEventRecord>>
+          : ISubmittableExtrinsicLegacy<ISubmittableResult<FrameSystemEventRecord>>)
         
     export type TxCall<Rv extends RpcVersion> = (...args: any[]) => ChainSubmittableExtrinsic<Rv>;    
 `;

--- a/packages/codegen/src/typink/generator/EventsGen.ts
+++ b/packages/codegen/src/typink/generator/EventsGen.ts
@@ -1,7 +1,7 @@
 import { ContractEventArg, ContractEventMeta } from '@dedot/contracts';
 import { stringCamelCase, stringPascalCase } from '@dedot/utils';
-import { beautifySourceCode, commentBlock, compileTemplate } from '../../utils';
-import { QueryGen } from './QueryGen';
+import { beautifySourceCode, commentBlock, compileTemplate } from '../../utils.js';
+import { QueryGen } from './QueryGen.js';
 
 export class EventsGen extends QueryGen {
   generate(useSubPaths: boolean = false) {

--- a/packages/types/src/extrinsic.ts
+++ b/packages/types/src/extrinsic.ts
@@ -24,7 +24,7 @@ export interface SignerOptions extends PayloadOptions {
 export type DryRunResult = ApplyExtrinsicResult;
 export type TxPaymentInfo = RuntimeDispatchInfo;
 
-export interface ISubmittableResult<EventRecord extends IEventRecord = IEventRecord, TxStatus extends any = any> {
+export interface ISubmittableResult<EventRecord extends IEventRecord = IEventRecord> {
   status: TxStatus;
   events: EventRecord[];
   dispatchError?: DispatchError;


### PR DESCRIPTION
Follow up on #184 & #185

Since we're using the same interface for transaction status, it's make sense to remove the generic over TxStatus now.