### PR TITLE
feat(api): add `getRuntimeVersion` to clients

### DIFF
--- a/packages/api/src/client/DedotClient.ts
+++ b/packages/api/src/client/DedotClient.ts
@@ -140,12 +140,16 @@ export class DedotClient<ChainApi extends VersionedGenericSubstrateApi = Substra
     const runtimeUpgraded = block.runtime && block.runtime.specVersion !== this._runtimeVersion?.specVersion;
     if (!runtimeUpgraded) return;
 
+    this.startRuntimeUpgrade();
+
     this._runtimeVersion = block.runtime;
 
     this.emit('runtimeUpgraded', this._runtimeVersion);
 
     const newMetadata = await this.fetchMetadata(undefined, this._runtimeVersion);
     await this.setupMetadata(newMetadata);
+
+    this.doneRuntimeUpgrade();
   };
 
   protected override async beforeDisconnect(): Promise<void> {

--- a/packages/api/src/client/LegacyClient.ts
+++ b/packages/api/src/client/LegacyClient.ts
@@ -130,12 +130,16 @@ export class LegacyClient<ChainApi extends VersionedGenericSubstrateApi = Substr
     this.rpc
       .state_subscribeRuntimeVersion(async (runtimeVersion: RuntimeVersion) => {
         if (runtimeVersion.specVersion !== this.runtimeVersion?.specVersion) {
+          this.startRuntimeUpgrade();
+
           this._runtimeVersion = this.toSubstrateRuntimeVersion(runtimeVersion);
 
           this.emit('runtimeUpgraded', this._runtimeVersion);
 
           const newMetadata = await this.fetchMetadata(undefined, this._runtimeVersion);
           await this.setupMetadata(newMetadata);
+
+          this.doneRuntimeUpgrade();
         }
       })
       .then((unsub) => {

--- a/packages/api/src/client/__tests__/LegacyClient.spec.ts
+++ b/packages/api/src/client/__tests__/LegacyClient.spec.ts
@@ -1,9 +1,10 @@
+import staticSubstrateV15 from '@polkadot/types-support/metadata/v15/substrate-hex';
 import { SubstrateRuntimeVersion } from '@dedot/api';
 import type { RuntimeVersion } from '@dedot/codecs';
 import { WsProvider } from '@dedot/providers';
 import type { AnyShape } from '@dedot/shape';
 import * as $ from '@dedot/shape';
-import { stringCamelCase, stringPascalCase, u8aToHex } from '@dedot/utils';
+import { HexString, stringCamelCase, stringPascalCase, u8aToHex } from '@dedot/utils';
 import { afterEach, beforeEach, describe, expect, expectTypeOf, it, vi } from 'vitest';
 import { LegacyClient } from '../LegacyClient.js';
 import MockProvider, { MockedRuntimeVersion } from './MockProvider.js';
@@ -312,6 +313,59 @@ describe('LegacyClient', () => {
         expect(providerSend).toBeCalledWith('state_call', ['Metadata_metadata', '0x', atHash]);
       });
     });
+
+    describe('runtime versions', () => {
+      it('should emit runtimeUpgraded event', async () => {
+        const originalRuntime = api.runtimeVersion;
+        const nextRuntime = { ...MockedRuntimeVersion, specVersion: originalRuntime.specVersion + 1 } as RuntimeVersion;
+
+        setTimeout(() => {
+          provider.notify('runtime-version-subscription-id', nextRuntime);
+        }, 100);
+
+        await new Promise<void>((resolve, reject) => {
+          api.on('runtimeUpgraded', (newRuntime: SubstrateRuntimeVersion) => {
+            try {
+              expect(nextRuntime.specVersion).toEqual(newRuntime.specVersion);
+              resolve();
+            } catch (e) {
+              reject(e);
+            }
+          });
+        });
+
+        expect(nextRuntime.specVersion).toEqual(api.runtimeVersion.specVersion);
+        expect(nextRuntime.specVersion).toEqual(originalRuntime.specVersion + 1);
+      });
+
+      it('getRuntimeVersion should return the latest version', async () => {
+        provider.setRpcRequests({
+          state_call: async (params) => {
+            return new Promise<HexString>((resolve) => {
+              setTimeout(() => {
+                if (params[0] === 'Metadata_metadata_at_version') {
+                  resolve(staticSubstrateV15);
+                } else {
+                  resolve('0x');
+                }
+              }, 300);
+            });
+          },
+        });
+
+        const originalRuntime = api.runtimeVersion;
+        const nextRuntime = { ...MockedRuntimeVersion, specVersion: originalRuntime.specVersion + 1 } as RuntimeVersion;
+        provider.notify('runtime-version-subscription-id', nextRuntime);
+
+        const newVersion = await new Promise<SubstrateRuntimeVersion>((resolve) => {
+          setTimeout(async () => {
+            resolve(await api.getRuntimeVersion());
+          }, 100);
+        });
+
+        expect(originalRuntime.specVersion + 1).toEqual(newVersion.specVersion);
+      });
+    });
   });
 
   describe('cache enabled', () => {
@@ -353,32 +407,6 @@ describe('LegacyClient', () => {
       expect(newApi.currentMetadataKey).toEqual(
         `RAW_META/0x0000000000000000000000000000000000000000000000000000000000000000/2`,
       );
-    });
-
-    it('should emit runtimeUpgraded event', async () => {
-      const provider = new MockProvider();
-      const newApi = await LegacyClient.new({ provider, cacheMetadata: true });
-
-      const originalRuntime = newApi.runtimeVersion;
-      const nextRuntime = { ...MockedRuntimeVersion, specVersion: originalRuntime.specVersion + 1 } as RuntimeVersion;
-
-      setTimeout(() => {
-        provider.notify('runtime-version-subscription-id', nextRuntime);
-      }, 100);
-
-      await new Promise<void>((resolve, reject) => {
-        newApi.on('runtimeUpgraded', (newRuntime: SubstrateRuntimeVersion) => {
-          try {
-            expect(nextRuntime.specVersion).toEqual(newRuntime.specVersion);
-            resolve();
-          } catch (e) {
-            reject(e);
-          }
-        });
-      });
-
-      expect(nextRuntime.specVersion).toEqual(newApi.runtimeVersion.specVersion);
-      expect(nextRuntime.specVersion).toEqual(originalRuntime.specVersion + 1);
     });
   });
 

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -120,6 +120,15 @@ export interface ISubstrateClient<
   options: ApiOptions;
   tx: ChainApi['tx'];
   at<ChainApiAt extends GenericSubstrateApi = ChainApi>(hash: BlockHash): Promise<ISubstrateClientAt<ChainApiAt>>;
+
+  /**
+   * Get current version of the runtime
+   * This is similar to `.runtimeVersion` but also ensure
+   * the corresponding metadata of this runtime version is downloaded & setup.
+   *
+   * This is helpful when you want to check runtime version to prepare for runtime upgrade
+   */
+  getRuntimeVersion(): Promise<SubstrateRuntimeVersion>;
 }
 
 /**


### PR DESCRIPTION
Closes #196

This new async version of `getRuntimeVersion` will ensure that the runtime upgrade process is done (download metadata, setup registry, caching ...) before returning the value. Helpful when we want to prepare for runtime upgrades.

So the process of preparing for new runtime upgrades would look like this:
```typescript
const client = await DedotClient<OldApi>.new(...)
const runtimeVersion = await client.getRuntimeVersion();

if (runtimeVersion.specVersion === NEW_SPEC_VERSION) {
   // casting the client to using the NewApi interface, generated from the new metadata
   const newClient: DedotClient<NewApi> = api as any; 
   newClient.tx.pallet.new_tx_call(...)
} else {
   client.tx.pallet.old_tx_call(...)
}

```

Pending some specs to verify the logics
