### PR TITLE
fix(contracts): missing fields for composite type

### DIFF
--- a/packages/contracts/src/types/shared.ts
+++ b/packages/contracts/src/types/shared.ts
@@ -69,7 +69,7 @@ export interface ContractTypeDef {
 }
 
 export interface CompositeType {
-  fields: {
+  fields?: {
     type: number;
     typeName: string;
     name?: string;

--- a/packages/contracts/src/utils.ts
+++ b/packages/contracts/src/utils.ts
@@ -47,11 +47,12 @@ export const normalizeContractTypeDef = (def: ContractTypeDef): TypeDef => {
   } else if (def.composite) {
     type = 'Struct';
     value = {
-      fields: def.composite.fields.map((one) => ({
-        typeId: one.type,
-        name: one.name,
-        typeName: one.typeName,
-      })),
+      fields:
+        def.composite.fields?.map((one) => ({
+          typeId: one.type,
+          name: one.name,
+          typeName: one.typeName,
+        })) || [],
     };
   } else if (def.primitive) {
     type = 'Primitive';


### PR DESCRIPTION
The `fields` prop in `composite` type can also be missing in  contract metadata as well, this will fix the case.