### PR TITLE
feat(client): add signer to ApiOptions

### DIFF
--- a/packages/api/src/client/BaseSubstrateClient.ts
+++ b/packages/api/src/client/BaseSubstrateClient.ts
@@ -1,3 +1,4 @@
+import { Signer } from '@polkadot/types/types';
 import { $Metadata, BlockHash, Hash, Metadata, PortableRegistry, RuntimeVersion } from '@dedot/codecs';
 import type { JsonRpcProvider } from '@dedot/providers';
 import { type IStorage, LocalStorage } from '@dedot/storage';
@@ -346,5 +347,9 @@ export abstract class BaseSubstrateClient<
 
   at<ChainApiAt extends GenericSubstrateApi = ChainApi[Rv]>(hash: BlockHash): Promise<ISubstrateClientAt<ChainApiAt>> {
     throw new Error('Unimplemented!');
+  }
+
+  setSigner(signer?: Signer): void {
+    this._options.signer = signer;
   }
 }

--- a/packages/api/src/extrinsic/submittable/BaseSubmittableExtrinsic.ts
+++ b/packages/api/src/extrinsic/submittable/BaseSubmittableExtrinsic.ts
@@ -1,3 +1,4 @@
+import { Signer } from '@polkadot/types/types';
 import { BlockHash, Extrinsic, Hash } from '@dedot/codecs';
 import {
   AddressOrPair,
@@ -46,7 +47,7 @@ export abstract class BaseSubmittableExtrinsic extends Extrinsic implements ISub
 
     await extra.init();
 
-    const { signer } = options || {};
+    const signer = this.#getSigner(options);
 
     let signature: HexString, alteredTx: HexString | Uint8Array | undefined;
     if (isKeyringPair(fromAccount)) {
@@ -142,5 +143,9 @@ export abstract class BaseSubmittableExtrinsic extends Extrinsic implements ISub
     if (alteredTx.callHex !== this.callHex) {
       throw new DedotError('Call data does not match, signer is not allowed to change tx call data.');
     }
+  }
+
+  #getSigner(options?: Partial<SignerOptions>): Signer | undefined {
+    return options?.signer || this.api.options.signer;
   }
 }

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -1,3 +1,4 @@
+import { Signer } from '@polkadot/types/types';
 import { BlockHash, Hash, Metadata, PortableRegistry } from '@dedot/codecs';
 import type { ConnectionStatus, JsonRpcProvider, ProviderEvent } from '@dedot/providers';
 import type { AnyShape } from '@dedot/shape';
@@ -59,6 +60,10 @@ export interface ApiOptions extends JsonRpcClientOptions {
    * @default blake2_256
    */
   hasher?: HashFn;
+  /**
+   * A signer instance to use for signing transactions
+   */
+  signer?: Signer;
 }
 
 export type ApiEvent = ProviderEvent | 'ready' | 'runtimeUpgraded';
@@ -129,6 +134,13 @@ export interface ISubstrateClient<
    * This is helpful when you want to check runtime version to prepare for runtime upgrade
    */
   getRuntimeVersion(): Promise<SubstrateRuntimeVersion>;
+
+  /**
+   * Update the signer instance for signing transactions
+   *
+   * @param signer
+   */
+  setSigner(signer?: Signer): void;
 }
 
 /**

--- a/zombienet-tests/src/0001-check-tx-alter-payload.ts
+++ b/zombienet-tests/src/0001-check-tx-alter-payload.ts
@@ -1,11 +1,9 @@
 import Keyring from '@polkadot/keyring';
-import { SignerResult } from '@polkadot/types/types';
+import { Signer, SignerResult } from '@polkadot/types/types';
 import { cryptoWaitReady } from '@polkadot/util-crypto';
 import { ExtrinsicSignature } from '@dedot/codecs';
 import { assert, u8aToHex } from '@dedot/utils';
 import { $, LegacyClient, WsProvider } from 'dedot';
-
-const BOB = '5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty';
 
 export const run = async (nodeName: any, networkInfo: any): Promise<void> => {
   await cryptoWaitReady();
@@ -44,32 +42,39 @@ export const run = async (nodeName: any, networkInfo: any): Promise<void> => {
     },
   };
 
-  return new Promise(async (resolve) => {
-    const remarkWithEventTx = await api.tx.system
-      .remarkWithEvent('Hello Dedot')
-      .sign(alice.address, { signer: alterSigner });
+  const verifySigner = (signer?: Signer) => {
+    return new Promise<void>(async (resolve) => {
+      const remarkWithEventTx = await api.tx.system.remarkWithEvent('Hello Dedot').sign(alice.address, { signer });
 
-    assert(remarkWithEventTx.signature, 'Tx signature should be available');
+      assert(remarkWithEventTx.signature, 'Tx signature should be available');
 
-    const unsub = await remarkWithEventTx.send(async ({ status, events, dispatchInfo }) => {
-      console.log('Transaction status', status.type);
+      const unsub = await remarkWithEventTx.send(async ({ status, events, dispatchInfo }) => {
+        console.log('Transaction status', status.type);
 
-      if (status.type === 'Finalized') {
-        const remarkEvent = events.map(({ event }) => event).find(api.events.system.Remarked.is);
-        const txFreePaidEvent = events
-          .map(({ event }) => event)
-          .find(api.events.transactionPayment.TransactionFeePaid.is);
+        if (status.type === 'Finalized') {
+          const remarkEvent = events.map(({ event }) => event).find(api.events.system.Remarked.is);
+          const txFreePaidEvent = events
+            .map(({ event }) => event)
+            .find(api.events.transactionPayment.TransactionFeePaid.is);
 
-        assert(
-          remarkEvent && remarkEvent.pallet === 'System' && remarkEvent.palletEvent.name === 'Remarked',
-          'System.Remarked event should be emitted',
-        );
+          assert(
+            remarkEvent && remarkEvent.pallet === 'System' && remarkEvent.palletEvent.name === 'Remarked',
+            'System.Remarked event should be emitted',
+          );
 
-        assert(txFreePaidEvent && txFreePaidEvent.palletEvent.data.tip === tip, 'Tip value is not correct');
+          assert(txFreePaidEvent && txFreePaidEvent.palletEvent.data.tip === tip, 'Tip value is not correct');
 
-        await unsub();
-        resolve();
-      }
+          await unsub();
+          resolve();
+        }
+      });
     });
-  });
+  };
+
+  // sign tx via custom signer option
+  await verifySigner(alterSigner);
+
+  // sign tx via global signer via ApiOptions
+  api.setSigner(alterSigner);
+  await verifySigner();
 };


### PR DESCRIPTION
Add a global option to setup signer instance to the client via ApiOptions, so we don't have to specify the `signer` everytime submitting a transaction.