### PR TITLE
fix(codegen): typink folder name contains space

### DIFF
--- a/packages/codegen/src/typink/index.ts
+++ b/packages/codegen/src/typink/index.ts
@@ -1,4 +1,5 @@
 import { ContractMetadata, parseRawMetadata } from '@dedot/contracts';
+import { stringDashCase } from '@dedot/utils';
 import fs from 'fs';
 import path from 'path';
 import {
@@ -20,8 +21,7 @@ export async function generateContractTypes(
 ) {
   let contractMetadata = typeof metadata === 'string' ? parseRawMetadata(metadata) : metadata;
 
-  contract = contract || contractMetadata.contract.name;
-  contract = contract.trim().toLowerCase().replaceAll(/\s+/g, '-');
+  contract = stringDashCase(contract || contractMetadata.contract.name);
 
   const dirPath = path.resolve(outDir, contract);
   const typesFileName = path.join(dirPath, `types.${extension}`);

--- a/packages/codegen/src/typink/index.ts
+++ b/packages/codegen/src/typink/index.ts
@@ -21,6 +21,7 @@ export async function generateContractTypes(
   let contractMetadata = typeof metadata === 'string' ? parseRawMetadata(metadata) : metadata;
 
   contract = contract || contractMetadata.contract.name;
+  contract = contract.trim().toLowerCase().replaceAll(/\s+/g, '-');
 
   const dirPath = path.resolve(outDir, contract);
   const typesFileName = path.join(dirPath, `types.${extension}`);

--- a/packages/utils/src/string/__tests__/cases.spec.ts
+++ b/packages/utils/src/string/__tests__/cases.spec.ts
@@ -9,6 +9,10 @@ describe('cases', () => {
       expect(stringCamelCase('Snake_case-...SomethingSomething    spaced')).toBe('snakeCaseSomethingSomethingSpaced');
     });
 
+    it('works correctly with whitespace leading or trailing string', () => {
+      expect(stringCamelCase('  Foo_bar-baz-Extra  ')).toBe('fooBarBazExtra');
+    })
+
     it('works correctly for String (class', (): void => {
       expect(stringCamelCase(String('Foo_bar-baz---test-_ spaced....Extra'))).toBe('fooBarBazTestSpacedExtra');
     });
@@ -63,6 +67,10 @@ describe('cases', () => {
     it('returns null as empty', (): void => {
       expect(stringLowerFirst(null)).toBe('');
     });
+
+    it('works correctly with whitespace leading string', () => {
+      expect(stringLowerFirst('  ABC')).toBe('aBC');
+    })
   });
 
   describe('stringUpperFirst', (): void => {
@@ -85,13 +93,18 @@ describe('cases', () => {
     it('returns null as empty', (): void => {
       expect(stringUpperFirst(null)).toBe('');
     });
+
+    it('works correctly with whitespace leading string', () => {
+      expect(stringUpperFirst('  aBC')).toBe('ABC');
+    })
   });
 
   describe('stringSnakeCase', () => {
     it.each([
       { input: 'anExampleWithCamelCase', expected: 'an_example_with_camel_case' },
       { input: 'AnExampleWithPascalCase', expected: 'an_example_with_pascal_case' },
-    ])('should turn camelCase or pascalCase string to snakeCase string', ({ input, expected }) => {
+      { input: '   AnExampleWithPascalCase   ', expected: 'an_example_with_pascal_case' },
+    ])('should turn camelCase or pascalCase or whitespace-leading-trailing string to snakeCase string', ({ input, expected }) => {
       expect(stringSnakeCase(input)).toEqual(expected);
     });
   });
@@ -101,7 +114,8 @@ describe('cases', () => {
       { input: 'anExampleWithCamelCase', expected: 'an-example-with-camel-case' },
       { input: 'AnExampleWithPascalCase', expected: 'an-example-with-pascal-case' },
       { input: 'an example with normal case', expected: 'an-example-with-normal-case' },
-    ])('should turn camelCase or pascalCase or normalCase string to dashCase string', ({ input, expected }) => {
+      { input: '   an example with normal case   ', expected: 'an-example-with-normal-case' },
+    ])('should turn camelCase or pascalCase or normalCase or whitespace-leading-trailing string to dashCase string', ({ input, expected }) => {
       expect(stringDashCase(input)).toEqual(expected);
     });
   });

--- a/packages/utils/src/string/__tests__/cases.spec.ts
+++ b/packages/utils/src/string/__tests__/cases.spec.ts
@@ -11,7 +11,7 @@ describe('cases', () => {
 
     it('works correctly with whitespace leading or trailing string', () => {
       expect(stringCamelCase('  Foo_bar-baz-Extra  ')).toBe('fooBarBazExtra');
-    })
+    });
 
     it('works correctly for String (class', (): void => {
       expect(stringCamelCase(String('Foo_bar-baz---test-_ spaced....Extra'))).toBe('fooBarBazTestSpacedExtra');
@@ -69,8 +69,8 @@ describe('cases', () => {
     });
 
     it('works correctly with whitespace leading string', () => {
-      expect(stringLowerFirst('  ABC')).toBe('aBC');
-    })
+      expect(stringLowerFirst('  ABC    ')).toBe('aBC');
+    });
   });
 
   describe('stringUpperFirst', (): void => {
@@ -95,8 +95,8 @@ describe('cases', () => {
     });
 
     it('works correctly with whitespace leading string', () => {
-      expect(stringUpperFirst('  aBC')).toBe('ABC');
-    })
+      expect(stringUpperFirst('  aBC  ')).toBe('ABC');
+    });
   });
 
   describe('stringSnakeCase', () => {
@@ -104,9 +104,12 @@ describe('cases', () => {
       { input: 'anExampleWithCamelCase', expected: 'an_example_with_camel_case' },
       { input: 'AnExampleWithPascalCase', expected: 'an_example_with_pascal_case' },
       { input: '   AnExampleWithPascalCase   ', expected: 'an_example_with_pascal_case' },
-    ])('should turn camelCase or pascalCase or whitespace-leading-trailing string to snakeCase string', ({ input, expected }) => {
-      expect(stringSnakeCase(input)).toEqual(expected);
-    });
+    ])(
+      'should turn camelCase or pascalCase or whitespace-leading-trailing string to snakeCase string',
+      ({ input, expected }) => {
+        expect(stringSnakeCase(input)).toEqual(expected);
+      },
+    );
   });
 
   describe('stringDashCase', () => {
@@ -115,8 +118,11 @@ describe('cases', () => {
       { input: 'AnExampleWithPascalCase', expected: 'an-example-with-pascal-case' },
       { input: 'an example with normal case', expected: 'an-example-with-normal-case' },
       { input: '   an example with normal case   ', expected: 'an-example-with-normal-case' },
-    ])('should turn camelCase or pascalCase or normalCase or whitespace-leading-trailing string to dashCase string', ({ input, expected }) => {
-      expect(stringDashCase(input)).toEqual(expected);
-    });
+    ])(
+      'should turn camelCase or pascalCase or normalCase or whitespace-leading-trailing string to dashCase string',
+      ({ input, expected }) => {
+        expect(stringDashCase(input)).toEqual(expected);
+      },
+    );
   });
 });

--- a/packages/utils/src/string/__tests__/cases.spec.ts
+++ b/packages/utils/src/string/__tests__/cases.spec.ts
@@ -1,7 +1,7 @@
 // Copyright 2017-2024 @polkadot/util authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 import { describe, it, expect } from 'vitest';
-import { stringCamelCase, stringUpperFirst, stringLowerFirst, stringSnakeCase } from '../cases.js';
+import { stringCamelCase, stringUpperFirst, stringLowerFirst, stringSnakeCase, stringDashCase } from '../cases.js';
 
 describe('cases', () => {
   describe('stringCamelCase', (): void => {
@@ -93,6 +93,16 @@ describe('cases', () => {
       { input: 'AnExampleWithPascalCase', expected: 'an_example_with_pascal_case' },
     ])('should turn camelCase or pascalCase string to snakeCase string', ({ input, expected }) => {
       expect(stringSnakeCase(input)).toEqual(expected);
+    });
+  });
+
+  describe('stringDashCase', () => {
+    it.each([
+      { input: 'anExampleWithCamelCase', expected: 'an-example-with-camel-case' },
+      { input: 'AnExampleWithPascalCase', expected: 'an-example-with-pascal-case' },
+      { input: 'an example with normal case', expected: 'an-example-with-normal-case' },
+    ])('should turn camelCase or pascalCase or normalCase string to dashCase string', ({ input, expected }) => {
+      expect(stringDashCase(input)).toEqual(expected);
     });
   });
 });

--- a/packages/utils/src/string/cases.ts
+++ b/packages/utils/src/string/cases.ts
@@ -88,17 +88,21 @@ export const stringSnakeCase = (input?: string | null) => {
 export const stringDashCase = (input?: string | null) => {
   if (!input) return '';
 
-  return stringSnakeCase(input).replaceAll(/_/g, '-')
+  return stringCamelCase(input).replaceAll(/[A-Z]/g, (letter) => `-${letter}`).toLowerCase();
 }
 
 export const stringLowerFirst = (input?: string | null) => {
   if (!input) return '';
+
+  input = input.trim()
 
   return CC_TO_LO[input.charCodeAt(0)] + input.slice(1);
 };
 
 export const stringUpperFirst = (input?: string | null) => {
   if (!input) return '';
+
+  input = input.trim()
 
   return CC_TO_UP[input.charCodeAt(0)] + input.slice(1);
 };

--- a/packages/utils/src/string/cases.ts
+++ b/packages/utils/src/string/cases.ts
@@ -88,13 +88,15 @@ export const stringSnakeCase = (input?: string | null) => {
 export const stringDashCase = (input?: string | null) => {
   if (!input) return '';
 
-  return stringCamelCase(input).replaceAll(/[A-Z]/g, (letter) => `-${letter}`).toLowerCase();
-}
+  return stringCamelCase(input)
+    .replaceAll(/[A-Z]/g, (letter) => `-${letter}`)
+    .toLowerCase();
+};
 
 export const stringLowerFirst = (input?: string | null) => {
   if (!input) return '';
 
-  input = input.trim()
+  input = input.trim();
 
   return CC_TO_LO[input.charCodeAt(0)] + input.slice(1);
 };
@@ -102,7 +104,7 @@ export const stringLowerFirst = (input?: string | null) => {
 export const stringUpperFirst = (input?: string | null) => {
   if (!input) return '';
 
-  input = input.trim()
+  input = input.trim();
 
   return CC_TO_UP[input.charCodeAt(0)] + input.slice(1);
 };

--- a/packages/utils/src/string/cases.ts
+++ b/packages/utils/src/string/cases.ts
@@ -85,6 +85,12 @@ export const stringSnakeCase = (input?: string | null) => {
   return stringCamelCase(input).replace(/[A-Z]/g, (letter) => `_${letter.toLowerCase()}`);
 };
 
+export const stringDashCase = (input?: string | null) => {
+  if (!input) return '';
+
+  return stringSnakeCase(input).replaceAll(/_/g, '-')
+}
+
 export const stringLowerFirst = (input?: string | null) => {
   if (!input) return '';
 


### PR DESCRIPTION
This PR changes the way `typink` handles contract metadata names contain whitespace. 

Previously: Directory names included whitespace (picture below). 
Now: Directory names are converted to hyphen-separated and lowercase (e.g., "flipper-contract").

![image](https://github.com/user-attachments/assets/63d4c3b9-07f6-4a7f-9830-4db8e99cd2af)
