### PR TITLE
fix(cli): disable cli version cmd

### DIFF
--- a/packages/cli/src/dedot.ts
+++ b/packages/cli/src/dedot.ts
@@ -8,6 +8,7 @@ export const dedot = (): void => {
     .showHelpOnFail(true)
     .command(chaintypes)
     .command(typink)
+    .version(false)
     .help('help', 'Show help instructions')
     .alias('h', 'help')
     .alias('v', 'version')


### PR DESCRIPTION
`dedot -v` is now showing the current version of the working project, not the version of the cli. For now, let's disable it.