### PR TITLE
breaking: expose SubstrateClient for Contract & ContractDeployer

### DIFF
--- a/packages/api/src/executor/Executor.ts
+++ b/packages/api/src/executor/Executor.ts
@@ -11,7 +11,7 @@ export abstract class Executor<ChainApi extends GenericSubstrateApi = GenericSub
   readonly #atBlockHash?: BlockHash;
 
   constructor(
-    public client: ISubstrateClientAt<ChainApi>,
+    readonly client: ISubstrateClientAt<ChainApi>,
     atBlockHash?: BlockHash,
   ) {
     this.#atBlockHash = atBlockHash;

--- a/packages/api/src/executor/Executor.ts
+++ b/packages/api/src/executor/Executor.ts
@@ -11,18 +11,18 @@ export abstract class Executor<ChainApi extends GenericSubstrateApi = GenericSub
   readonly #atBlockHash?: BlockHash;
 
   constructor(
-    public api: ISubstrateClientAt<ChainApi>,
+    public client: ISubstrateClientAt<ChainApi>,
     atBlockHash?: BlockHash,
   ) {
     this.#atBlockHash = atBlockHash;
   }
 
   get atBlockHash() {
-    return this.#atBlockHash || this.api.atBlockHash;
+    return this.#atBlockHash || this.client.atBlockHash;
   }
 
   get registry() {
-    return this.api.registry;
+    return this.client.registry;
   }
 
   get metadata() {
@@ -41,7 +41,7 @@ export abstract class Executor<ChainApi extends GenericSubstrateApi = GenericSub
     try {
       return this.doExecute(...paths);
     } catch (e: any) {
-      if (!this.api.options?.throwOnUnknownApi && e instanceof UnknownApiError) {
+      if (!this.client.options?.throwOnUnknownApi && e instanceof UnknownApiError) {
         return undefined;
       }
 

--- a/packages/api/src/executor/RuntimeApiExecutor.ts
+++ b/packages/api/src/executor/RuntimeApiExecutor.ts
@@ -77,7 +77,7 @@ export class RuntimeApiExecutor<ChainApi extends GenericSubstrateApi = GenericSu
     const args = [func, params];
     if (at) args.push(at);
 
-    return this.api.rpc.state_call(...args);
+    return this.client.rpc.state_call(...args);
   }
 
   tryDecode(callSpec: RuntimeApiMethodSpec, raw: any) {
@@ -111,7 +111,7 @@ export class RuntimeApiExecutor<ChainApi extends GenericSubstrateApi = GenericSu
 
     if (!isNumber(targetVersion)) return undefined;
 
-    const userDefinedSpec = this.#findDefinedSpec(this.api.options.runtimeApis, runtimeApi, method, targetVersion);
+    const userDefinedSpec = this.#findDefinedSpec(this.client.options.runtimeApis, runtimeApi, method, targetVersion);
     if (userDefinedSpec) return userDefinedSpec;
 
     const methodDef = this.#findRuntimeApiMethodDef(runtimeApi, method);
@@ -152,7 +152,7 @@ export class RuntimeApiExecutor<ChainApi extends GenericSubstrateApi = GenericSu
   #findTargetRuntimeApiVersion(runtimeApi: string): number | undefined {
     const runtimeApiHash = calcRuntimeApiHash(runtimeApi);
     try {
-      return this.api.runtimeVersion.apis[runtimeApiHash] || FallbackRuntimeApis[runtimeApiHash];
+      return this.client.runtimeVersion.apis[runtimeApiHash] || FallbackRuntimeApis[runtimeApiHash];
     } catch {
       return FallbackRuntimeApis[runtimeApiHash];
     }

--- a/packages/api/src/executor/StorageQueryExecutor.ts
+++ b/packages/api/src/executor/StorageQueryExecutor.ts
@@ -106,7 +106,7 @@ export class StorageQueryExecutor<
       const pageSize = pagination?.pageSize || DEFAULT_KEYS_PAGE_SIZE;
       const startKey = pagination?.startKey || entry.prefixKey;
 
-      return await this.api.rpc.state_getKeysPaged(entry.prefixKey, pageSize, startKey, this.atBlockHash);
+      return await this.client.rpc.state_getKeysPaged(entry.prefixKey, pageSize, startKey, this.atBlockHash);
     };
 
     const pagedKeys = async (pagination?: PaginationOptions): Promise<any[]> => {
@@ -124,7 +124,7 @@ export class StorageQueryExecutor<
   }
 
   protected async queryStorage(keys: StorageKey[], hash?: BlockHash): Promise<Record<StorageKey, Option<StorageData>>> {
-    const changeSets: StorageChangeSet[] = await this.api.rpc.state_queryStorageAt(keys, hash);
+    const changeSets: StorageChangeSet[] = await this.client.rpc.state_queryStorageAt(keys, hash);
 
     return changeSets[0].changes.reduce(
       (o, [key, value]) => {
@@ -138,7 +138,7 @@ export class StorageQueryExecutor<
   protected subscribeStorage(keys: StorageKey[], callback: Callback<Array<StorageData | undefined>>): Promise<Unsub> {
     const lastChanges = {} as Record<StorageKey, StorageData | undefined>;
 
-    return this.api.rpc.state_subscribeStorage(keys, (changeSet: StorageChangeSet) => {
+    return this.client.rpc.state_subscribeStorage(keys, (changeSet: StorageChangeSet) => {
       changeSet.changes.forEach(([key, value]) => {
         if (lastChanges[key] !== value) {
           lastChanges[key] = value ?? undefined;

--- a/packages/api/src/executor/TxExecutor.ts
+++ b/packages/api/src/executor/TxExecutor.ts
@@ -59,6 +59,6 @@ export class TxExecutor<ChainApi extends GenericSubstrateApi = GenericSubstrateA
   }
 
   protected createExtrinsic(call: IRuntimeTxCall): any {
-    return new SubmittableExtrinsic(this.api as ISubstrateClient<ChainApi>, call);
+    return new SubmittableExtrinsic(this.client as ISubstrateClient<ChainApi>, call);
   }
 }

--- a/packages/api/src/executor/v2/RuntimeApiExecutorV2.ts
+++ b/packages/api/src/executor/v2/RuntimeApiExecutorV2.ts
@@ -12,12 +12,12 @@ export class RuntimeApiExecutorV2<
   ChainApi extends GenericSubstrateApi = GenericSubstrateApi,
 > extends RuntimeApiExecutor<ChainApi> {
   constructor(
-    api: ISubstrateClientAt<ChainApi>,
+    client: ISubstrateClientAt<ChainApi>,
     public chainHead: ChainHead,
     atBlockHash?: BlockHash,
   ) {
-    assert(api.rpcVersion === 'v2', 'Only supports JSON-RPC v2');
-    super(api, atBlockHash);
+    assert(client.rpcVersion === 'v2', 'Only supports JSON-RPC v2');
+    super(client, atBlockHash);
   }
 
   protected override stateCall(callParams: StateCallParams): Promise<HexString> {

--- a/packages/api/src/executor/v2/StorageQueryExecutorV2.ts
+++ b/packages/api/src/executor/v2/StorageQueryExecutorV2.ts
@@ -13,12 +13,12 @@ export class StorageQueryExecutorV2<
   ChainApi extends GenericSubstrateApi = GenericSubstrateApi,
 > extends StorageQueryExecutor<ChainApi> {
   constructor(
-    api: ISubstrateClientAt<ChainApi>,
+    client: ISubstrateClientAt<ChainApi>,
     public chainHead: ChainHead,
     atBlockHash?: BlockHash,
   ) {
-    assert(api.rpcVersion === 'v2', 'Only supports JSON-RPC v2');
-    super(api, atBlockHash);
+    assert(client.rpcVersion === 'v2', 'Only supports JSON-RPC v2');
+    super(client, atBlockHash);
   }
 
   protected override exposeStorageMapMethods(entry: QueryableStorage): Record<string, AsyncMethod> {

--- a/packages/api/src/executor/v2/TxExecutorV2.ts
+++ b/packages/api/src/executor/v2/TxExecutorV2.ts
@@ -17,6 +17,6 @@ export class TxExecutorV2<
   }
 
   protected override createExtrinsic(call: IRuntimeTxCall): any {
-    return new SubmittableExtrinsicV2(this.api as DedotClient, call);
+    return new SubmittableExtrinsicV2(this.client as DedotClient, call);
   }
 }

--- a/packages/api/src/extrinsic/extensions/ExtraSignedExtension.ts
+++ b/packages/api/src/extrinsic/extensions/ExtraSignedExtension.ts
@@ -45,7 +45,7 @@ export class ExtraSignedExtension extends SignedExtension<any[], any[]> {
 
   #getSignedExtensions() {
     return this.#signedExtensionDefs.map((extDef) => {
-      const { signedExtensions: userSignedExtensions = {} } = this.api.options;
+      const { signedExtensions: userSignedExtensions = {} } = this.client.options;
 
       const Extension =
         userSignedExtensions[extDef.ident as keyof typeof knownSignedExtensions] ||
@@ -53,7 +53,7 @@ export class ExtraSignedExtension extends SignedExtension<any[], any[]> {
 
       assert(Extension, `SignedExtension for ${extDef.ident} not found`);
 
-      return new Extension(this.api, {
+      return new Extension(this.client, {
         ...ensurePresence(this.options),
         def: extDef,
       });

--- a/packages/api/src/extrinsic/extensions/SignedExtension.ts
+++ b/packages/api/src/extrinsic/extensions/SignedExtension.ts
@@ -30,8 +30,8 @@ export abstract class SignedExtension<Data extends any = {}, AdditionalSigned ex
   additionalSigned: AdditionalSigned;
 
   constructor(
-    public client: ISubstrateClient,
-    public options?: SignedExtensionOptions,
+    readonly client: ISubstrateClient,
+    readonly options?: SignedExtensionOptions,
   ) {
     this.data = {} as unknown as Data;
     this.additionalSigned = [] as unknown as AdditionalSigned;

--- a/packages/api/src/extrinsic/extensions/SignedExtension.ts
+++ b/packages/api/src/extrinsic/extensions/SignedExtension.ts
@@ -30,7 +30,7 @@ export abstract class SignedExtension<Data extends any = {}, AdditionalSigned ex
   additionalSigned: AdditionalSigned;
 
   constructor(
-    public api: ISubstrateClient,
+    public client: ISubstrateClient,
     public options?: SignedExtensionOptions,
   ) {
     this.data = {} as unknown as Data;
@@ -54,7 +54,7 @@ export abstract class SignedExtension<Data extends any = {}, AdditionalSigned ex
   }
 
   get registry() {
-    return this.api.registry;
+    return this.client.registry;
   }
 
   get signedExtensionDef() {

--- a/packages/api/src/extrinsic/extensions/known/CheckGenesis.ts
+++ b/packages/api/src/extrinsic/extensions/known/CheckGenesis.ts
@@ -8,7 +8,7 @@ import { SignedExtension } from '../SignedExtension.js';
  */
 export class CheckGenesis extends SignedExtension<{}, Hash> {
   async init() {
-    this.additionalSigned = ensurePresence(this.api.genesisHash);
+    this.additionalSigned = ensurePresence(this.client.genesisHash);
   }
 
   toPayload(): Partial<SignerPayloadJSON> {

--- a/packages/api/src/extrinsic/extensions/known/CheckMortality.ts
+++ b/packages/api/src/extrinsic/extensions/known/CheckMortality.ts
@@ -27,7 +27,7 @@ export class CheckMortality extends SignedExtension<EraLike, Hash> {
   }
 
   async #getSigningHeader(): Promise<SigningHeader> {
-    if (this.api.rpcVersion === 'v2') {
+    if (this.client.rpcVersion === 'v2') {
       return this.#getSigningHeaderRpcV2();
     }
 
@@ -35,7 +35,7 @@ export class CheckMortality extends SignedExtension<EraLike, Hash> {
   }
 
   async #getSigningHeaderRpcV2(): Promise<SigningHeader> {
-    const api = this.api as DedotClient;
+    const api = this.client as DedotClient;
     // TODO similar to the legacy, we should account for the case finality is lagging behind
     const finalizedBlock = await api.chainHead.finalizedBlock();
 
@@ -48,8 +48,8 @@ export class CheckMortality extends SignedExtension<EraLike, Hash> {
   // Ref: https://github.com/polkadot-js/api/blob/3bdf49b0428a62f16b3222b9a31bfefa43c1ca55/packages/api-derive/src/tx/signingInfo.ts#L34-L64
   async #getSigningHeaderViaLegacyRpc(): Promise<SigningHeader> {
     const [header, finalizedHash] = await Promise.all([
-      this.api.rpc.chain_getHeader(),
-      this.api.rpc.chain_getFinalizedHead(),
+      this.client.rpc.chain_getHeader(),
+      this.client.rpc.chain_getFinalizedHead(),
     ]);
 
     assert(header, 'Current header not found');
@@ -60,10 +60,10 @@ export class CheckMortality extends SignedExtension<EraLike, Hash> {
         if (parentHash.length === 0 || isZeroHex(parentHash)) {
           return header;
         } else {
-          return this.api.rpc.chain_getHeader(parentHash);
+          return this.client.rpc.chain_getHeader(parentHash);
         }
       }),
-      this.api.rpc.chain_getHeader(finalizedHash),
+      this.client.rpc.chain_getHeader(finalizedHash),
     ]);
 
     assert(currentHeader, 'Cannot determine current header');
@@ -77,7 +77,7 @@ export class CheckMortality extends SignedExtension<EraLike, Hash> {
 
   async #toSigningHeader(header: Header): Promise<SigningHeader> {
     const { number } = header;
-    const hash = (await this.api.rpc.chain_getBlockHash(header.number))!;
+    const hash = (await this.client.rpc.chain_getBlockHash(header.number))!;
 
     return { hash, number };
   }
@@ -98,7 +98,7 @@ export class CheckMortality extends SignedExtension<EraLike, Hash> {
 
   #getConst<T>(pallet: string, name: string): T | undefined {
     try {
-      return this.api.consts[pallet][name];
+      return this.client.consts[pallet][name];
     } catch {
       // ignore this on purpose
     }

--- a/packages/api/src/extrinsic/extensions/known/CheckNonce.ts
+++ b/packages/api/src/extrinsic/extensions/known/CheckNonce.ts
@@ -16,11 +16,11 @@ export class CheckNonce extends SignedExtension<number> {
     assert(signerAddress, 'Signer address not found');
 
     try {
-      return (await this.api.query.system.account(signerAddress)).nonce;
+      return (await this.client.query.system.account(signerAddress)).nonce;
     } catch {}
 
     try {
-      return await this.api.call.accountNonceApi.accountNonce(signerAddress);
+      return await this.client.call.accountNonceApi.accountNonce(signerAddress);
     } catch {}
 
     // TODO fallback to api.rpc.system_accountNextIndex if needed

--- a/packages/api/src/extrinsic/extensions/known/CheckSpecVersion.ts
+++ b/packages/api/src/extrinsic/extensions/known/CheckSpecVersion.ts
@@ -7,7 +7,7 @@ import { SignedExtension } from '../SignedExtension.js';
  */
 export class CheckSpecVersion extends SignedExtension<{}, number> {
   async init(): Promise<void> {
-    this.additionalSigned = this.api.runtimeVersion.specVersion;
+    this.additionalSigned = this.client.runtimeVersion.specVersion;
   }
 
   toPayload(): Partial<SignerPayloadJSON> {

--- a/packages/api/src/extrinsic/extensions/known/CheckTxVersion.ts
+++ b/packages/api/src/extrinsic/extensions/known/CheckTxVersion.ts
@@ -7,7 +7,7 @@ import { SignedExtension } from '../SignedExtension.js';
  */
 export class CheckTxVersion extends SignedExtension<{}, number> {
   async init(): Promise<void> {
-    this.additionalSigned = this.api.runtimeVersion.transactionVersion;
+    this.additionalSigned = this.client.runtimeVersion.transactionVersion;
   }
 
   toPayload(): Partial<SignerPayloadJSON> {

--- a/packages/api/src/extrinsic/submittable/BaseSubmittableExtrinsic.ts
+++ b/packages/api/src/extrinsic/submittable/BaseSubmittableExtrinsic.ts
@@ -23,10 +23,10 @@ export abstract class BaseSubmittableExtrinsic extends Extrinsic implements ISub
   #alterTx?: HexString;
 
   constructor(
-    public api: ISubstrateClient,
+    public client: ISubstrateClient,
     call: IRuntimeTxCall,
   ) {
-    super(api.registry, call);
+    super(client.registry, call);
   }
 
   async paymentInfo(account: AddressOrPair, options?: Partial<PayloadOptions>): Promise<TxPaymentInfo> {
@@ -34,13 +34,13 @@ export abstract class BaseSubmittableExtrinsic extends Extrinsic implements ISub
 
     const txU8a = this.toU8a();
 
-    const api = this.api as ISubstrateClient<SubstrateApi[RpcVersion]>;
+    const api = this.client as ISubstrateClient<SubstrateApi[RpcVersion]>;
     return api.call.transactionPaymentApi.queryInfo(txU8a, txU8a.length);
   }
 
   async sign(fromAccount: AddressOrPair, options?: Partial<SignerOptions>) {
     const address = isKeyringPair(fromAccount) ? fromAccount.address : fromAccount.toString();
-    const extra = new ExtraSignedExtension(this.api, {
+    const extra = new ExtraSignedExtension(this.client, {
       signerAddress: address,
       payloadOptions: options,
     });
@@ -116,7 +116,7 @@ export abstract class BaseSubmittableExtrinsic extends Extrinsic implements ISub
   }
 
   protected async getSystemEventsAt(hash: BlockHash): Promise<FrameSystemEventRecord[]> {
-    const atApi = (await this.api.at(hash)) as ISubstrateClientAt<SubstrateApi[RpcVersion]>;
+    const atApi = (await this.client.at(hash)) as ISubstrateClientAt<SubstrateApi[RpcVersion]>;
     return await atApi.query.system.events();
   }
 
@@ -146,6 +146,6 @@ export abstract class BaseSubmittableExtrinsic extends Extrinsic implements ISub
   }
 
   #getSigner(options?: Partial<SignerOptions>): Signer | undefined {
-    return options?.signer || this.api.options.signer;
+    return options?.signer || this.client.options.signer;
   }
 }

--- a/packages/api/src/extrinsic/submittable/BaseSubmittableExtrinsic.ts
+++ b/packages/api/src/extrinsic/submittable/BaseSubmittableExtrinsic.ts
@@ -23,7 +23,7 @@ export abstract class BaseSubmittableExtrinsic extends Extrinsic implements ISub
   #alterTx?: HexString;
 
   constructor(
-    public client: ISubstrateClient,
+    readonly client: ISubstrateClient,
     call: IRuntimeTxCall,
   ) {
     super(client.registry, call);

--- a/packages/api/src/extrinsic/submittable/SubmittableExtrinsic.ts
+++ b/packages/api/src/extrinsic/submittable/SubmittableExtrinsic.ts
@@ -19,7 +19,7 @@ import { toTxStatus } from './utils.js';
  */
 export class SubmittableExtrinsic extends BaseSubmittableExtrinsic implements ISubmittableExtrinsicLegacy {
   async dryRun(account: AddressOrPair, optionsOrHash?: Partial<SignerOptions> | BlockHash): Promise<DryRunResult> {
-    const dryRunFn = this.api.rpc.system_dryRun;
+    const dryRunFn = this.client.rpc.system_dryRun;
 
     if (isHex(optionsOrHash)) {
       return dryRunFn(this.toHex(), optionsOrHash);
@@ -37,12 +37,12 @@ export class SubmittableExtrinsic extends BaseSubmittableExtrinsic implements IS
     const txHash = this.hash;
 
     if (isSubscription) {
-      return this.api.rpc.author_submitAndWatchExtrinsic(txHex, async (txStatus: TransactionStatus) => {
+      return this.client.rpc.author_submitAndWatchExtrinsic(txHex, async (txStatus: TransactionStatus) => {
         if (txStatus.type === 'InBlock' || txStatus.type === 'Finalized') {
           const blockHash: BlockHash = txStatus.value;
 
           const [signedBlock, blockEvents] = await Promise.all([
-            this.api.rpc.chain_getBlock(blockHash),
+            this.client.rpc.chain_getBlock(blockHash),
             this.getSystemEventsAt(blockHash),
           ]);
 
@@ -60,7 +60,7 @@ export class SubmittableExtrinsic extends BaseSubmittableExtrinsic implements IS
         }
       });
     } else {
-      return this.api.rpc.author_submitExtrinsic(txHex);
+      return this.client.rpc.author_submitExtrinsic(txHex);
     }
   }
 }

--- a/packages/api/src/extrinsic/submittable/SubmittableExtrinsicV2.ts
+++ b/packages/api/src/extrinsic/submittable/SubmittableExtrinsicV2.ts
@@ -15,20 +15,20 @@ type TxFound = { blockHash: BlockHash; blockNumber: number; index: number; event
  */
 export class SubmittableExtrinsicV2 extends BaseSubmittableExtrinsic {
   constructor(
-    public api: DedotClient,
+    public client: DedotClient,
     call: IRuntimeTxCall,
   ) {
-    super(api, call);
+    super(client, call);
   }
 
   async #send(callback: Callback<ISubmittableResult>): Promise<Unsub> {
-    const api = this.api;
+    const api = this.client;
     const txHex = this.toHex();
     const txHash = this.hash;
 
     // validate the transaction
     // https://github.com/paritytech/json-rpc-interface-spec/issues/55#issuecomment-1609011150
-    const finalizedHash = await this.api.chainHead.finalizedHash();
+    const finalizedHash = await this.client.chainHead.finalizedHash();
     const validateTx = async (hash: BlockHash) => {
       const apiAt = await api.at(hash);
       return apiAt.call.taggedTransactionQueue.validateTransaction('External', txHex, hash);

--- a/packages/codegen/src/typink/templates/index.hbs
+++ b/packages/codegen/src/typink/templates/index.hbs
@@ -9,7 +9,7 @@ import { ContractEvents } from './events';
 
 export * from './types';
 
-export interface {{{interfaceName}}}<Rv extends RpcVersion = RpcV2, ChainApi extends VersionedGenericSubstrateApi = SubstrateApi> extends GenericContractApi<Rv, ChainApi> {
+export interface {{{interfaceName}}}<Rv extends RpcVersion = RpcVersion, ChainApi extends VersionedGenericSubstrateApi = SubstrateApi> extends GenericContractApi<Rv, ChainApi> {
     query: ContractQuery<ChainApi[Rv]>;
     tx: ContractTx<ChainApi[Rv]>;
     constructorQuery: ConstructorQuery<ChainApi[Rv]>;

--- a/packages/contracts/src/executor/ConstructorQueryExecutor.ts
+++ b/packages/contracts/src/executor/ConstructorQueryExecutor.ts
@@ -28,8 +28,8 @@ import { Executor } from './Executor.js';
 export class ConstructorQueryExecutor<ChainApi extends GenericSubstrateApi> extends Executor<ChainApi> {
   protected readonly code: Hash | Uint8Array | HexString | string;
 
-  constructor(api: ISubstrateClient<ChainApi>, registry: TypinkRegistry, code: Hash | Uint8Array | string) {
-    super(api, registry);
+  constructor(client: ISubstrateClient<ChainApi>, registry: TypinkRegistry, code: Hash | Uint8Array | string) {
+    super(client, registry);
     this.code = code;
   }
 
@@ -53,7 +53,7 @@ export class ConstructorQueryExecutor<ChainApi extends GenericSubstrateApi> exte
         value: this.code,
       } as PalletContractsPrimitivesCode;
 
-      const raw: PalletContractsPrimitivesContractResultResult = await this.api.call.contractsApi.instantiate(
+      const raw: PalletContractsPrimitivesContractResultResult = await this.client.call.contractsApi.instantiate(
         caller,
         value,
         gasLimit,

--- a/packages/contracts/src/executor/ConstructorTxExecutor.ts
+++ b/packages/contracts/src/executor/ConstructorTxExecutor.ts
@@ -20,8 +20,8 @@ import { Executor } from './Executor.js';
 export class ConstructorTxExecutor<ChainApi extends GenericSubstrateApi> extends Executor<ChainApi> {
   protected readonly code: Hash | Uint8Array | HexString | string;
 
-  constructor(api: ISubstrateClient<ChainApi>, registry: TypinkRegistry, code: Hash | Uint8Array | string) {
-    super(api, registry);
+  constructor(client: ISubstrateClient<ChainApi>, registry: TypinkRegistry, code: Hash | Uint8Array | string) {
+    super(client, registry);
     this.code = code;
   }
 
@@ -42,9 +42,23 @@ export class ConstructorTxExecutor<ChainApi extends GenericSubstrateApi> extends
       const bytes = u8aToHex(concatU8a(hexToU8a(meta.selector), ...formattedInputs));
 
       if (isWasm(this.code)) {
-        return this.api.tx.contracts.instantiateWithCode(value, gasLimit, storageDepositLimit, this.code, bytes, salt);
+        return this.client.tx.contracts.instantiateWithCode(
+          value,
+          gasLimit,
+          storageDepositLimit,
+          this.code,
+          bytes,
+          salt,
+        );
       } else {
-        return this.api.tx.contracts.instantiate(value, gasLimit, storageDepositLimit, this.code, bytes, salt);
+        return this.client.tx.contracts.instantiate(
+          value, // prettier-end-here
+          gasLimit,
+          storageDepositLimit,
+          this.code,
+          bytes,
+          salt,
+        );
       }
     };
 

--- a/packages/contracts/src/executor/Executor.ts
+++ b/packages/contracts/src/executor/Executor.ts
@@ -1,38 +1,30 @@
 import { ISubstrateClient } from '@dedot/api';
 import { SubstrateApi } from '@dedot/api/chaintypes';
-import { AccountId32 } from '@dedot/codecs';
+import { AccountId32, AccountId32Like } from '@dedot/codecs';
 import { GenericSubstrateApi, RpcVersion } from '@dedot/types';
 import { TypinkRegistry } from '../TypinkRegistry.js';
 import { ContractMessageArg, ContractMessage } from '../types/index.js';
 import { ContractMetadata } from '../types/index.js';
 
 export abstract class Executor<ChainApi extends GenericSubstrateApi = SubstrateApi[RpcVersion]> {
-  readonly #api: ISubstrateClient<ChainApi>;
-  readonly #registry: TypinkRegistry;
   readonly #address?: AccountId32;
 
-  constructor(api: ISubstrateClient<ChainApi>, registry: TypinkRegistry, address?: AccountId32) {
-    this.#api = api;
-    this.#registry = registry;
+  constructor(
+    readonly client: ISubstrateClient<ChainApi>,
+    readonly registry: TypinkRegistry,
+    address?: AccountId32Like,
+  ) {
     if (address) {
       this.#address = new AccountId32(address);
     }
   }
 
-  get api(): ISubstrateClient<ChainApi> {
-    return this.#api;
-  }
-
   get metadata(): ContractMetadata {
-    return this.#registry.metadata;
+    return this.registry.metadata;
   }
 
   get address(): AccountId32 | undefined {
     return this.#address;
-  }
-
-  get registry(): TypinkRegistry {
-    return this.#registry;
   }
 
   abstract doExecute(...paths: string[]): unknown;

--- a/packages/contracts/src/executor/QueryExecutor.ts
+++ b/packages/contracts/src/executor/QueryExecutor.ts
@@ -28,7 +28,7 @@ export class QueryExecutor<ChainApi extends GenericSubstrateApi> extends Executo
       const formattedInputs = args.map((arg, index) => this.tryEncode(arg, params[index]));
       const bytes = u8aToHex(concatU8a(hexToU8a(meta.selector), ...formattedInputs));
 
-      const raw: PalletContractsPrimitivesContractResult = await this.api.call.contractsApi.call(
+      const raw: PalletContractsPrimitivesContractResult = await this.client.call.contractsApi.call(
         caller,
         this.address,
         value,

--- a/packages/contracts/src/executor/TxExecutor.ts
+++ b/packages/contracts/src/executor/TxExecutor.ts
@@ -20,7 +20,7 @@ export class TxExecutor<ChainApi extends GenericSubstrateApi> extends Executor<C
       const formattedInputs = args.map((arg, index) => this.tryEncode(arg, params[index]));
       const bytes = u8aToHex(concatU8a(hexToU8a(meta.selector), ...formattedInputs));
 
-      return this.api.tx.contracts.call(this.address, value, gasLimit, storageDepositLimit, bytes);
+      return this.client.tx.contracts.call(this.address, value, gasLimit, storageDepositLimit, bytes);
     };
 
     callFn.meta = meta;

--- a/packages/contracts/src/utils.ts
+++ b/packages/contracts/src/utils.ts
@@ -1,6 +1,7 @@
 import { ISubstrateClient } from '@dedot/api';
+import { SubstrateApi } from '@dedot/api/chaintypes';
 import { PortableType, TypeDef } from '@dedot/codecs';
-import { GenericSubstrateApi } from '@dedot/types';
+import { GenericSubstrateApi, RpcVersion } from '@dedot/types';
 import { stringCamelCase } from '@dedot/utils';
 import { Executor } from './executor/index.js';
 import { ContractMetadata, ContractTypeDef, ReturnFlags } from './types/index.js';
@@ -101,9 +102,9 @@ export function newProxyChain<ChainApi extends GenericSubstrateApi>(carrier: Exe
   });
 }
 
-export function ensureSupportContractsPallet<ChainApi extends GenericSubstrateApi>(api: ISubstrateClient<ChainApi>) {
+export function ensureSupportContractsPallet(client: ISubstrateClient<SubstrateApi[RpcVersion]>) {
   try {
-    !!api.call.contractsApi.call.meta && !!api.tx.contracts.call.meta;
+    !!client.call.contractsApi.call.meta && !!client.tx.contracts.call.meta;
   } catch {
     throw new Error('Contracts pallet is not available');
   }

--- a/zombienet-tests/src/contracts/flipper/index.d.ts
+++ b/zombienet-tests/src/contracts/flipper/index.d.ts
@@ -2,7 +2,7 @@
 
 import type { SubstrateApi } from 'dedot/chaintypes';
 import type { GenericContractApi } from 'dedot/contracts';
-import type { RpcV2, RpcVersion, VersionedGenericSubstrateApi } from 'dedot/types';
+import type { RpcVersion, VersionedGenericSubstrateApi } from 'dedot/types';
 import { ConstructorQuery } from './constructor-query';
 import { ConstructorTx } from './constructor-tx';
 import { ContractEvents } from './events';
@@ -13,7 +13,7 @@ import type { InkPrimitivesLangError } from './types';
 export * from './types';
 
 export interface FlipperContractApi<
-  Rv extends RpcVersion = RpcV2,
+  Rv extends RpcVersion = RpcVersion,
   ChainApi extends VersionedGenericSubstrateApi = SubstrateApi,
 > extends GenericContractApi<Rv, ChainApi> {
   query: ContractQuery<ChainApi[Rv]>;


### PR DESCRIPTION
This also comes with:
- Renaming client variable for consistency in code base, this will change the exposed client in some internal primitives, so I'll mark this PR as breaking, but this does not break high-level API.
- Fix a minor RpcVersion selection issue with generated ContractApi interface