### PR TITLE
fix: optimize smoldot performance for `.queryMulti`

### DIFF
--- a/packages/api/src/json-rpc/group/ChainHead/ChainHead.ts
+++ b/packages/api/src/json-rpc/group/ChainHead/ChainHead.ts
@@ -525,7 +525,7 @@ export class ChainHead extends JsonRpcGroup<ChainHeadEvent> {
       return await operation();
     } catch (e) {
       if (e instanceof ChainHeadError && e.retryStrategy) {
-        return this.#retryOperation(e.retryStrategy, operation);
+        return await this.#retryOperation(e.retryStrategy, operation);
       }
 
       throw e;
@@ -550,7 +550,7 @@ export class ChainHead extends JsonRpcGroup<ChainHeadEvent> {
     } catch (e: any) {
       // retry again until success, TODO we might need to limit the number of retries
       if (e instanceof ChainHeadError && e.retryStrategy) {
-        return this.#retryOperation(e.retryStrategy, retry);
+        return await this.#retryOperation(e.retryStrategy, retry);
       }
 
       throw e;
@@ -702,7 +702,7 @@ export class ChainHead extends JsonRpcGroup<ChainHeadEvent> {
       return results;
     } catch (e) {
       if (e instanceof ChainHeadBlockPrunedError && shouldRetryOnPrunedBlock) {
-        return this.storage(items, childTrie);
+        return await this.storage(items, childTrie);
       }
 
       throw e;

--- a/packages/api/src/json-rpc/group/ChainHead/ChainHead.ts
+++ b/packages/api/src/json-rpc/group/ChainHead/ChainHead.ts
@@ -696,7 +696,7 @@ export class ChainHead extends JsonRpcGroup<ChainHeadEvent> {
         const fetchItem = async (item: StorageQuery): Promise<StorageResult> => {
           const [newBatch, newDiscardedItems] = await this.#getStorage([item], childTrie ?? null, hash);
           if (newDiscardedItems.length > 0) {
-            return fetchItem(newDiscardedItems[0]);
+            return fetchItem(item);
           }
 
           if (newBatch.length === 0) {

--- a/packages/api/src/storage/NewStorageQuery.ts
+++ b/packages/api/src/storage/NewStorageQuery.ts
@@ -68,8 +68,7 @@ export class NewStorageQuery<
     const pullQueue = new AsyncQueue();
 
     // Function to pull storage values and call the callback if there are changes
-    const pull = async ({ hash, number }: PinnedBlock) => {
-      // console.log('pull', shortenAddress(hash), number, 'queue size', pullQueue.size);
+    const pull = async ({ hash }: PinnedBlock) => {
       try {
         // Query storage using ChainHead API with the abort signal
         const storageQueries = keys.map((key) => ({ type: 'value' as const, key }));
@@ -110,14 +109,7 @@ export class NewStorageQuery<
 
     // Subscribe to best block events
     const unsub = this.client.on('bestBlock', (block: PinnedBlock) => {
-      if (pullQueue.size >= 3) {
-        // console.log('queue is overloaded, clean it up now!');
-        pullQueue.cancel();
-      }
-
-      // console.log('queue', shortenAddress(block.hash), block.number);
       pullQueue.enqueue(() => pull(block)).catch(noop);
-      // console.log('queue size', pullQueue.size);
     });
 
     return async () => {

--- a/packages/api/src/storage/NewStorageQuery.ts
+++ b/packages/api/src/storage/NewStorageQuery.ts
@@ -65,6 +65,10 @@ export class NewStorageQuery<
 
     // Track the latest changes for each key
     const latestChanges: Record<StorageKey, StorageData | undefined> = {};
+    // Using a queue here to make sure we don't accidentally
+    // put a pressure the json-rpc server in-case new blocks stack up too fast
+    // in case we send a lot of requests at the same time
+    // or the block time is small enough with elastic scaling
     const pullQueue = new AsyncQueue();
 
     // Function to pull storage values and call the callback if there are changes

--- a/packages/api/src/storage/NewStorageQuery.ts
+++ b/packages/api/src/storage/NewStorageQuery.ts
@@ -1,6 +1,6 @@
 import { BlockHash, StorageData, StorageKey } from '@dedot/codecs';
 import type { Callback, RpcV2, Unsub, VersionedGenericSubstrateApi } from '@dedot/types';
-import { AsyncQueue, noop, shortenAddress } from '@dedot/utils';
+import { AsyncQueue, noop } from '@dedot/utils';
 import type { SubstrateApi } from '../chaintypes/index.js';
 import { DedotClient } from '../client/DedotClient.js';
 import { PinnedBlock } from '../json-rpc/group/ChainHead/ChainHead.js';

--- a/packages/api/src/storage/NewStorageQuery.ts
+++ b/packages/api/src/storage/NewStorageQuery.ts
@@ -1,10 +1,9 @@
 import { BlockHash, StorageData, StorageKey } from '@dedot/codecs';
 import type { Callback, RpcV2, Unsub, VersionedGenericSubstrateApi } from '@dedot/types';
-import { AsyncQueue, noop } from '@dedot/utils';
+import { AsyncQueue } from '@dedot/utils';
 import type { SubstrateApi } from '../chaintypes/index.js';
 import { DedotClient } from '../client/DedotClient.js';
 import { PinnedBlock } from '../json-rpc/group/ChainHead/ChainHead.js';
-import { ChainHeadBlockNotPinnedError } from '../json-rpc/index.js';
 import { BaseStorageQuery } from './BaseStorageQuery.js';
 
 /**
@@ -73,7 +72,7 @@ export class NewStorageQuery<
 
     // Function to pull storage values and call the callback if there are changes
     const pull = async ({ hash }: PinnedBlock) => {
-      // Query storage using ChainHead API with the abort signal
+      // Query storage using ChainHead API
       const storageQueries = keys.map((key) => ({ type: 'value' as const, key }));
       const rawResults = await this.client.chainHead.storage(storageQueries, undefined, hash);
 


### PR DESCRIPTION
Fix a critical performance issue with smoldot where `.queryMulti` performs worse if we send multiple keys at once via chainHead.storage API. This might potentially related to caching issue on smoldot side.

For now:
- Smoldot: Send each key one by one
- WebSocket: Send all keys at once.