### PR TITLE
fix: send `withSignedTransaction:true` by default and allow alter tx call data

### DIFF
--- a/packages/api/src/extrinsic/extensions/ExtraSignedExtension.ts
+++ b/packages/api/src/extrinsic/extensions/ExtraSignedExtension.ts
@@ -1,10 +1,10 @@
+import type { SignedExtensionDefLatest } from '@dedot/codecs';
 import * as $ from '@dedot/shape';
 import { SignerPayloadJSON, SignerPayloadRaw } from '@dedot/types';
 import { ensurePresence, HexString, u8aToHex } from '@dedot/utils';
-import { ISignedExtension, SignedExtension } from './SignedExtension.js';
 import { FallbackSignedExtension, isEmptyStructOrTuple } from './FallbackSignedExtension.js';
+import { ISignedExtension, SignedExtension } from './SignedExtension.js';
 import { knownSignedExtensions } from './known/index.js';
-import type { SignedExtensionDefLatest } from '@dedot/codecs';
 
 export class ExtraSignedExtension extends SignedExtension<any[], any[]> {
   #signedExtensions?: ISignedExtension[];
@@ -65,7 +65,7 @@ export class ExtraSignedExtension extends SignedExtension<any[], any[]> {
             ...ensurePresence(this.options),
             def: extDef,
           },
-          extDef.ident
+          extDef.ident,
         );
       }
 
@@ -81,7 +81,7 @@ export class ExtraSignedExtension extends SignedExtension<any[], any[]> {
    */
   private isRequireNoExternalInputs(extDef: SignedExtensionDefLatest): boolean {
     return (
-      isEmptyStructOrTuple(this.registry, extDef.typeId) &&
+      isEmptyStructOrTuple(this.registry, extDef.typeId) && // prettier-end-here
       isEmptyStructOrTuple(this.registry, extDef.additionalSigned)
     );
   }
@@ -89,9 +89,16 @@ export class ExtraSignedExtension extends SignedExtension<any[], any[]> {
   toPayload(call: HexString = '0x'): SignerPayloadJSON {
     const signedExtensions = this.#signedExtensions!.map((se) => se.identifier);
     const { version } = this.registry.metadata.extrinsic;
+    const { signerAddress } = this.options!;
 
     return Object.assign(
-      { address: this.options!.signerAddress, signedExtensions, version, method: call },
+      {
+        address: signerAddress,
+        signedExtensions,
+        version,
+        method: call,
+        withSignedTransaction: true, // allow signer/wallet to alter transaction by default
+      },
       ...this.#signedExtensions!.map((se) => se.toPayload()),
     ) as SignerPayloadJSON;
   }

--- a/packages/api/src/extrinsic/submittable/BaseSubmittableExtrinsic.ts
+++ b/packages/api/src/extrinsic/submittable/BaseSubmittableExtrinsic.ts
@@ -138,11 +138,6 @@ export abstract class BaseSubmittableExtrinsic extends Extrinsic implements ISub
     if (!alteredTx.signed) {
       throw new DedotError('Altered transaction from signer is not signed');
     }
-
-    // Signer's not allow the change the call data
-    if (alteredTx.callHex !== this.callHex) {
-      throw new DedotError('Call data does not match, signer is not allowed to change tx call data.');
-    }
   }
 
   #getSigner(options?: Partial<SignerOptions>): InjectedSigner | undefined {

--- a/zombienet-tests/src/0001-check-tx-alter-payload.ts
+++ b/zombienet-tests/src/0001-check-tx-alter-payload.ts
@@ -1,7 +1,7 @@
 import Keyring from '@polkadot/keyring';
 import { cryptoWaitReady } from '@polkadot/util-crypto';
 import { ExtrinsicSignature } from '@dedot/codecs';
-import { InjectedSigner, SignerResult } from '@dedot/types';
+import { InjectedSigner, SignerPayloadJSON, SignerResult } from '@dedot/types';
 import { assert, u8aToHex } from '@dedot/utils';
 import { $, LegacyClient, WsProvider } from 'dedot';
 
@@ -16,7 +16,9 @@ export const run = async (nodeName: any, networkInfo: any): Promise<void> => {
   const tip = 1_000n;
 
   const alterSigner = {
-    signPayload: async (): Promise<SignerResult> => {
+    signPayload: async (payload: SignerPayloadJSON): Promise<SignerResult> => {
+      assert(payload.withSignedTransaction, 'withSignedTransaction should be true');
+
       // Changing the payload to add some tip
       // So we should expect the tip should be presence where the original tx does not have
       // Proving that the original tx payload is already alter to add the tip


### PR DESCRIPTION
Dedot does support signer/wallet to alter transaction with #190

But with [this change](https://github.com/polkadot-js/api/pull/5920) from PJS, wallet/signer now expect a `withSignedTransaction: true` in the payload to enable altering transaction. This PR is to:

1. Send `withSignedTransaction: true` by default to signer to allow altering transaction.
2. We also allow signer/wallet to alter call data.

