### PR TITLE
feat(providers): WsProvider to support list of endpoints

### DIFF
--- a/packages/providers/src/__tests__/utils.spec.ts
+++ b/packages/providers/src/__tests__/utils.spec.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it, vi } from 'vitest';
+import { pickRandomItem } from '../utils.js';
+
+describe('selectRandomItem', () => {
+  it('throws error for empty array', () => {
+    expect(() => pickRandomItem([])).toThrow('Cannot select from empty array');
+  });
+
+  it('returns the only item from single-item array', () => {
+    const items = ['only-item'];
+    const result = pickRandomItem(items);
+    expect(result).toBe('only-item');
+  });
+
+  it('returns an item from the array', () => {
+    const items = ['item1', 'item2', 'item3'];
+    const result = pickRandomItem(items);
+    expect(items).toContain(result);
+  });
+
+  it('excludes specified item when possible', () => {
+    const items = ['item1', 'item2', 'item3'];
+    const excludeItem = 'item2';
+
+    // Mock Math.random to always return 0 for predictable testing
+    const mockRandom = vi.spyOn(Math, 'random').mockReturnValue(0);
+
+    const result = pickRandomItem(items, excludeItem);
+
+    // Should return first item from filtered array ['item1', 'item3']
+    expect(result).toBe('item1');
+    expect(result).not.toBe(excludeItem);
+
+    mockRandom.mockRestore();
+  });
+
+  it('falls back to original array when all items would be excluded', () => {
+    const items = ['only-item'];
+    const excludeItem = 'only-item';
+
+    const result = pickRandomItem(items, excludeItem);
+    expect(result).toBe('only-item');
+  });
+
+  it('works with different data types', () => {
+    const numbers = [1, 2, 3, 4, 5];
+    const result = pickRandomItem(numbers, 3);
+    expect(numbers).toContain(result);
+
+    const objects = [{ id: 1 }, { id: 2 }, { id: 3 }];
+    const excludeObj = { id: 2 };
+    const objResult = pickRandomItem(objects, excludeObj);
+    expect(objects).toContain(objResult);
+  });
+
+  it('handles undefined excludeItem correctly', () => {
+    const items = ['item1', 'item2', 'item3'];
+    const result = pickRandomItem(items, undefined);
+    expect(items).toContain(result);
+  });
+
+  it('distributes selection randomly', () => {
+    const items = ['item1', 'item2', 'item3'];
+    const results = new Set();
+
+    // Run multiple times to check randomness
+    for (let i = 0; i < 100; i++) {
+      const result = pickRandomItem(items);
+      results.add(result);
+    }
+
+    // Should have selected multiple different items
+    expect(results.size).toBeGreaterThan(1);
+  });
+
+  it('respects exclusion in random distribution', () => {
+    const items = ['item1', 'item2', 'item3'];
+    const excludeItem = 'item2';
+    const results = new Set();
+
+    // Run multiple times to check that excluded item is never selected
+    for (let i = 0; i < 100; i++) {
+      const result = pickRandomItem(items, excludeItem);
+      results.add(result);
+    }
+
+    // Should never contain the excluded item
+    expect(results.has(excludeItem)).toBe(false);
+    // Should contain other items
+    expect(results.has('item1')).toBe(true);
+    expect(results.has('item3')).toBe(true);
+  });
+});

--- a/packages/providers/src/__tests__/utils.spec.ts
+++ b/packages/providers/src/__tests__/utils.spec.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it, vi } from 'vitest';
 import { pickRandomItem } from '../utils.js';
 
-describe('selectRandomItem', () => {
+describe('pickRandomItem', () => {
   it('throws error for empty array', () => {
-    expect(() => pickRandomItem([])).toThrow('Cannot select from empty array');
+    expect(() => pickRandomItem([])).toThrow('Cannot pick from empty array');
   });
 
   it('returns the only item from single-item array', () => {
@@ -46,11 +46,6 @@ describe('selectRandomItem', () => {
     const numbers = [1, 2, 3, 4, 5];
     const result = pickRandomItem(numbers, 3);
     expect(numbers).toContain(result);
-
-    const objects = [{ id: 1 }, { id: 2 }, { id: 3 }];
-    const excludeObj = { id: 2 };
-    const objResult = pickRandomItem(objects, excludeObj);
-    expect(objects).toContain(objResult);
   });
 
   it('handles undefined excludeItem correctly', () => {

--- a/packages/providers/src/utils.ts
+++ b/packages/providers/src/utils.ts
@@ -1,0 +1,20 @@
+/**
+ * Picks a random item from an array, optionally excluding a specific item
+ *
+ * @param items Array of items to select from
+ * @param excludeItem Optional item to exclude from selection
+ * @returns A randomly selected item
+ * @throws Error if the items array is empty
+ */
+export function pickRandomItem<T>(items: T[], excludeItem?: T): T {
+  if (items.length === 0) {
+    throw new Error('Cannot pick from empty array');
+  }
+
+  const availableItems = excludeItem !== undefined ? items.filter((item) => item !== excludeItem) : items;
+
+  // Fallback to original array if no items left after filtering
+  const finalItems = availableItems.length > 0 ? availableItems : items;
+
+  return finalItems[Math.floor(Math.random() * finalItems.length)];
+}

--- a/packages/providers/src/utils.ts
+++ b/packages/providers/src/utils.ts
@@ -1,3 +1,5 @@
+import { DedotError } from '@dedot/utils';
+
 /**
  * Picks a random item from an array, optionally excluding a specific item
  *
@@ -17,4 +19,15 @@ export function pickRandomItem<T>(items: T[], excludeItem?: T): T {
   const finalItems = availableItems.length > 0 ? availableItems : items;
 
   return finalItems[Math.floor(Math.random() * finalItems.length)];
+}
+
+/**
+ * Validate that an endpoint is properly formatted
+ */
+export function validateEndpoint(endpoint: string): string {
+  if (!endpoint || (!endpoint.startsWith('ws://') && !endpoint.startsWith('wss://'))) {
+    throw new DedotError(`Invalid websocket endpoint ${endpoint}, a valid endpoint should start with wss:// or ws://`);
+  }
+
+  return endpoint;
 }

--- a/packages/providers/src/ws/WsProvider.ts
+++ b/packages/providers/src/ws/WsProvider.ts
@@ -1,5 +1,5 @@
 import { WebSocket } from '@polkadot/x-ws';
-import { assert } from '@dedot/utils';
+import { assert, DedotError } from '@dedot/utils';
 import { SubscriptionProvider } from '../base/index.js';
 import { JsonRpcRequest } from '../types.js';
 
@@ -160,7 +160,9 @@ export class WsProvider extends SubscriptionProvider {
    */
   #validateEndpoint(endpoint: string): void {
     if (!endpoint || (!endpoint.startsWith('ws://') && !endpoint.startsWith('wss://'))) {
-      throw new Error(`Invalid websocket endpoint ${endpoint}, a valid endpoint should start with wss:// or ws://`);
+      throw new DedotError(
+        `Invalid websocket endpoint ${endpoint}, a valid endpoint should start with wss:// or ws://`,
+      );
     }
   }
 
@@ -261,7 +263,7 @@ export class WsProvider extends SubscriptionProvider {
 
       Object.values(this._handlers).forEach(({ from, defer, request }) => {
         if (now - from > timeout) {
-          defer.reject(new Error(`Request timed out after ${timeout}ms`));
+          defer.reject(new DedotError(`Request timed out after ${timeout}ms`));
           delete this._handlers[request.id];
         }
       });
@@ -284,7 +286,7 @@ export class WsProvider extends SubscriptionProvider {
   #onSocketClose = (event: CloseEvent) => {
     this.#clearWs();
 
-    const error = new Error(`disconnected from ${this.#currentEndpoint}: ${event.code} - ${event.reason}`);
+    const error = new DedotError(`disconnected from ${this.#currentEndpoint}: ${event.code} - ${event.reason}`);
 
     // Reject all pending requests
     Object.values(this._handlers).forEach(({ defer }) => {

--- a/packages/providers/src/ws/__tests__/WsProvider.spec.ts
+++ b/packages/providers/src/ws/__tests__/WsProvider.spec.ts
@@ -300,15 +300,15 @@ describe('WsProvider', () => {
       testMockServers = [];
     };
 
+    beforeEach(() => {
+      setupTestServers([FAKE_WS_URL_3, FAKE_WS_URL_4]);
+    });
+
     afterEach(() => {
       stopTestServers();
     });
 
     describe('Basic Array Functionality', () => {
-      beforeEach(() => {
-        setupTestServers([FAKE_WS_URL_3, FAKE_WS_URL_4]);
-      });
-
       it('connects with array of valid endpoints', async () => {
         const endpoints = [FAKE_WS_URL, FAKE_WS_URL_2];
         const provider = new WsProvider(endpoints);
@@ -346,10 +346,6 @@ describe('WsProvider', () => {
     });
 
     describe('Random Selection', () => {
-      beforeEach(() => {
-        setupTestServers([FAKE_WS_URL_3]);
-      });
-
       it('selects random endpoint from array on initial connection', async () => {
         const endpoints = [FAKE_WS_URL, FAKE_WS_URL_2, FAKE_WS_URL_3];
 
@@ -367,10 +363,6 @@ describe('WsProvider', () => {
     });
 
     describe('Reconnection with Arrays', () => {
-      beforeEach(() => {
-        setupTestServers([FAKE_WS_URL_3, FAKE_WS_URL_4]);
-      });
-
       it('selects different endpoint on reconnection when possible', async () => {
         const endpoints = [FAKE_WS_URL, FAKE_WS_URL_2];
         const provider = new WsProvider({
@@ -516,10 +508,6 @@ describe('WsProvider', () => {
     });
 
     describe('Edge Cases', () => {
-      beforeEach(() => {
-        setupTestServers([FAKE_WS_URL_3, FAKE_WS_URL_4]);
-      });
-
       it('handles reconnection when current endpoint becomes unavailable', async () => {
         // This test simulates the scenario where the current endpoint is no longer available
         // and should be excluded from the next selection
@@ -590,10 +578,6 @@ describe('WsProvider', () => {
     });
 
     describe('Integration', () => {
-      beforeEach(() => {
-        setupTestServers([FAKE_WS_URL_3, FAKE_WS_URL_4]);
-      });
-
       it('maintains subscription reestablishment on reconnection', async () => {
         const endpoints = [FAKE_WS_URL, FAKE_WS_URL_2];
         const provider = new WsProvider({


### PR DESCRIPTION
Enhanced `WsProvider` to accept an array of WebSocket endpoints for automatic failover. Endpoints are randomly selected on initial connection, and reconnection attempts exclude previously failed endpoints when possible.

#### Example

```typescript
// Single endpoint
const provider = new WsProvider('wss://rpc.polkadot.io');

// Multiple endpoints for failover
const provider = new WsProvider([
  'wss://rpc.polkadot.io',
  'wss://polkadot-rpc.dwellir.com',
  'wss://polkadot.api.onfinality.io/public-ws'
]);
```

This new feature leverages the endpointSelector we had previously in #462 
