### PR TITLE
feat: emit current endpoint on WsProvider connected

### DIFF
--- a/examples/scripts/multiple-endpoints.ts
+++ b/examples/scripts/multiple-endpoints.ts
@@ -1,0 +1,21 @@
+import { DedotClient, WsProvider } from 'dedot';
+import { waitFor } from 'dedot/utils';
+
+// Multiple endpoints for failover
+const provider = new WsProvider([
+  'wss://rpc.polkadot.io',
+  'wss://polkadot-rpc.dwellir.com',
+  'wss://polkadot.api.onfinality.io/public-ws',
+]);
+
+const client = new DedotClient(provider);
+
+client.on('connected', (connectedUrl) => {
+  console.log('Connected Endpoint:', connectedUrl);
+});
+
+await client.connect();
+
+await waitFor(1000);
+
+await client.disconnect();

--- a/packages/api/src/client/DedotClient.ts
+++ b/packages/api/src/client/DedotClient.ts
@@ -170,7 +170,9 @@ export class DedotClient<ChainApi extends VersionedGenericSubstrateApi = Substra
   }
 
   protected override onDisconnected = async () => {
-    this.chainHead.unfollow().catch(noop);
+    try {
+      this.chainHead.unfollow().catch(noop);
+    } catch {}
   };
 
   protected override cleanUp() {

--- a/packages/api/src/json-rpc/JsonRpcClient.ts
+++ b/packages/api/src/json-rpc/JsonRpcClient.ts
@@ -105,24 +105,24 @@ export class JsonRpcClient<
     });
   }
 
-  #onConnected = async () => {
+  #onConnected = async (...args: any[]) => {
     // @ts-ignore
-    this.emit('connected');
+    this.emit('connected', ...args);
   };
 
-  #onDisconnected = async () => {
+  #onDisconnected = async (...args: any[]) => {
     // @ts-ignore
-    this.emit('disconnected');
+    this.emit('disconnected', ...args);
   };
 
-  #onReconnecting = async () => {
+  #onReconnecting = async (...args: any[]) => {
     // @ts-ignore
-    this.emit('reconnecting');
+    this.emit('reconnecting', ...args);
   };
 
-  #onError = async (e: Error) => {
+  #onError = async (...args: any[]) => {
     // @ts-ignore
-    this.emit('error', e);
+    this.emit('error', ...args);
   };
 
   async disconnect(): Promise<void> {

--- a/packages/providers/src/base/SubscriptionProvider.ts
+++ b/packages/providers/src/base/SubscriptionProvider.ts
@@ -57,11 +57,11 @@ export abstract class SubscriptionProvider extends EventEmitter<ProviderEvent> i
     throw new Error('Unimplemented!');
   }
 
-  protected _setStatus(status: ConnectionStatus) {
+  protected _setStatus(status: ConnectionStatus, ...args: any[]) {
     if (this._status === status) return;
 
     this._status = status;
-    this.emit(status);
+    this.emit(status, ...args);
   }
 
   protected _cleanUp() {

--- a/packages/providers/src/ws/WsProvider.ts
+++ b/packages/providers/src/ws/WsProvider.ts
@@ -229,7 +229,7 @@ export class WsProvider extends SubscriptionProvider {
     // Connection successful - reset attempt counter
     this.#attempt = 1;
 
-    this._setStatus('connected');
+    this._setStatus('connected', this.#currentEndpoint);
 
     // re-subscribe to previous subscriptions if this is a reconnect
     Object.keys(this._subscriptions).forEach((subkey) => {

--- a/packages/providers/src/ws/WsProvider.ts
+++ b/packages/providers/src/ws/WsProvider.ts
@@ -114,7 +114,7 @@ export class WsProvider extends SubscriptionProvider {
   #timeoutTimer?: ReturnType<typeof setInterval>;
 
   // Connection state tracking
-  #attempt: number = 1;
+  #attempt: number = 0;
   #currentEndpoint?: string;
 
   constructor(options: WsProviderOptions | string | string[] | WsEndpointSelector) {
@@ -203,6 +203,8 @@ export class WsProvider extends SubscriptionProvider {
   async #connectAndRetry() {
     assert(!this.#ws, 'Websocket connection already exists');
 
+    this.#attempt += 1;
+
     try {
       await this.#doConnect();
     } catch (e) {
@@ -219,15 +221,13 @@ export class WsProvider extends SubscriptionProvider {
 
     setTimeout(() => {
       this._setStatus('reconnecting');
-      this.#attempt += 1;
-
       this.#connectAndRetry().catch(console.error);
     }, this.#options.retryDelayMs);
   }
 
   #onSocketOpen = async (event: Event) => {
     // Connection successful - reset attempt counter
-    this.#attempt = 1;
+    this.#attempt = 0;
 
     this._setStatus('connected', this.#currentEndpoint);
 


### PR DESCRIPTION
Emit current connected endpoint on `WsProvider` connected event.

```ts
const provider = new WsProvider([
  'wss://rpc.polkadot.io',
  'wss://polkadot-rpc.dwellir.com',
  'wss://polkadot.api.onfinality.io/public-ws',
]);

provider.on('connected', (connectedUrl) => {
  console.log('Connected Endpoint:', connectedUrl);
});

await provider.connect();
```