### PR TITLE
feat: helper to sign from json payload

### DIFF
--- a/examples/scripts/keyring.ts
+++ b/examples/scripts/keyring.ts
@@ -1,0 +1,13 @@
+import Keyring from '@polkadot/keyring';
+import { cryptoWaitReady } from '@polkadot/util-crypto';
+
+const keyring = new Keyring({ type: 'sr25519' });
+
+export const devPairs = async () => {
+  await cryptoWaitReady();
+  const alice = keyring.addFromUri('//Alice');
+
+  return {
+    alice,
+  };
+};

--- a/examples/scripts/merkleized-metadata.ts
+++ b/examples/scripts/merkleized-metadata.ts
@@ -3,6 +3,7 @@ import { cryptoWaitReady } from '@polkadot/util-crypto';
 import { DedotClient, WsProvider } from 'dedot';
 import { MerkleizedMetadata } from 'dedot/merkleized-metadata';
 import { u8aToHex } from 'dedot/utils';
+import { devPairs } from './keyring.js';
 
 /**
  * Example of calculating metadata hash for a real chain
@@ -12,9 +13,7 @@ import { u8aToHex } from 'dedot/utils';
  * tsx ./packages/merkleized-metadata/examples/calculate-hash.ts
  * ```
  */
-await cryptoWaitReady();
-const keyring = new Keyring({ type: 'sr25519' });
-const alice = keyring.addFromUri('//Alice');
+const { alice } = await devPairs();
 
 // Create a dedot client
 console.log('Connecting to Polkadot...');

--- a/examples/scripts/sign-from-json-payload.ts
+++ b/examples/scripts/sign-from-json-payload.ts
@@ -1,5 +1,5 @@
-import { SignerPayloadJSON, SignerResult } from '@dedot/types';
 import { DedotClient, ExtraSignedExtension, signRawMessage, WsProvider } from 'dedot';
+import { SignerPayloadJSON, SignerResult } from 'dedot/types';
 import { assert, HexString, u8aToHex } from 'dedot/utils';
 import { devPairs } from './keyring.js';
 
@@ -12,11 +12,11 @@ const signer = {
     const extra = new ExtraSignedExtension(client, { signerAddress: payload.address });
     await extra.fromPayload(payload);
 
-    const rawPayload = extra.toRawPayload(payload.method as HexString).data;
+    const rawPayload = extra.toRawPayload(payload.method).data;
     const signature = u8aToHex(signRawMessage(alice, rawPayload));
 
     assert(
-      JSON.stringify(extra.toPayload(payload.method as HexString)) === JSON.stringify(payload),
+      JSON.stringify(extra.toPayload(payload.method)) === JSON.stringify(payload),
       'JSON Payload should remain the same!',
     );
 

--- a/examples/scripts/sign-from-json-payload.ts
+++ b/examples/scripts/sign-from-json-payload.ts
@@ -1,0 +1,44 @@
+import { IKeyringPair, SignerPayloadJSON, SignerResult } from '@dedot/types';
+import { DedotClient, ExtraSignedExtension, WsProvider } from 'dedot';
+import { HexString, assert, hexToU8a, u8aToHex, blake2AsU8a } from 'dedot/utils';
+import { devPairs } from './keyring.js';
+
+const client = await DedotClient.new(new WsProvider('wss://rpc.ibp.network/westend'));
+
+const { alice } = await devPairs();
+
+export function signRaw(signerPair: IKeyringPair, raw: HexString | string): Uint8Array {
+  const u8a = hexToU8a(raw);
+  // Ref: https://github.com/paritytech/polkadot-sdk/blob/943697fa693a4da6ef481ef93df522accb7d0583/substrate/primitives/runtime/src/generic/unchecked_extrinsic.rs#L234-L238
+  const toSignRaw = u8a.length > 256 ? blake2AsU8a(u8a) : u8a;
+
+  return signerPair.sign(toSignRaw, { withType: true });
+}
+
+const signer = {
+  signPayload: async (payload: SignerPayloadJSON): Promise<SignerResult> => {
+    const extra = new ExtraSignedExtension(client, { signerAddress: payload.address });
+    await extra.fromPayload(payload);
+
+    const signature = u8aToHex(signRaw(alice, extra.toRawPayload(payload.method as HexString).data));
+
+    assert(
+      JSON.stringify(extra.toPayload(payload.method as HexString)) === JSON.stringify(payload),
+      'JSON Payload should remain the same!',
+    );
+
+    return {
+      id: Date.now(),
+      signature,
+    };
+  },
+};
+
+await client.tx.system
+  .remarkWithEvent('Hello') // -
+  .signAndSend(alice.address, { signer, tip: 1_000_0000n }, ({ status }) => {
+    console.log(status);
+  })
+  .untilFinalized();
+
+await client.disconnect();

--- a/examples/scripts/sign-from-json-payload.ts
+++ b/examples/scripts/sign-from-json-payload.ts
@@ -1,26 +1,19 @@
-import { IKeyringPair, SignerPayloadJSON, SignerResult } from '@dedot/types';
-import { DedotClient, ExtraSignedExtension, WsProvider } from 'dedot';
-import { HexString, assert, hexToU8a, u8aToHex, blake2AsU8a } from 'dedot/utils';
+import { SignerPayloadJSON, SignerResult } from '@dedot/types';
+import { DedotClient, ExtraSignedExtension, signRawMessage, WsProvider } from 'dedot';
+import { assert, HexString, u8aToHex } from 'dedot/utils';
 import { devPairs } from './keyring.js';
 
 const client = await DedotClient.new(new WsProvider('wss://rpc.ibp.network/westend'));
 
 const { alice } = await devPairs();
 
-export function signRaw(signerPair: IKeyringPair, raw: HexString | string): Uint8Array {
-  const u8a = hexToU8a(raw);
-  // Ref: https://github.com/paritytech/polkadot-sdk/blob/943697fa693a4da6ef481ef93df522accb7d0583/substrate/primitives/runtime/src/generic/unchecked_extrinsic.rs#L234-L238
-  const toSignRaw = u8a.length > 256 ? blake2AsU8a(u8a) : u8a;
-
-  return signerPair.sign(toSignRaw, { withType: true });
-}
-
 const signer = {
   signPayload: async (payload: SignerPayloadJSON): Promise<SignerResult> => {
     const extra = new ExtraSignedExtension(client, { signerAddress: payload.address });
     await extra.fromPayload(payload);
 
-    const signature = u8aToHex(signRaw(alice, extra.toRawPayload(payload.method as HexString).data));
+    const rawPayload = extra.toRawPayload(payload.method as HexString).data;
+    const signature = u8aToHex(signRawMessage(alice, rawPayload));
 
     assert(
       JSON.stringify(extra.toPayload(payload.method as HexString)) === JSON.stringify(payload),

--- a/examples/scripts/sign-from-json-payload.ts
+++ b/examples/scripts/sign-from-json-payload.ts
@@ -1,6 +1,6 @@
 import { DedotClient, ExtraSignedExtension, signRawMessage, WsProvider } from 'dedot';
 import { SignerPayloadJSON, SignerResult } from 'dedot/types';
-import { assert, HexString, u8aToHex } from 'dedot/utils';
+import { assert, u8aToHex } from 'dedot/utils';
 import { devPairs } from './keyring.js';
 
 const client = await DedotClient.new(new WsProvider('wss://rpc.ibp.network/westend'));

--- a/packages/api/src/extrinsic/extensions/ExtraSignedExtension.ts
+++ b/packages/api/src/extrinsic/extensions/ExtraSignedExtension.ts
@@ -18,6 +18,15 @@ export class ExtraSignedExtension extends SignedExtension<any[], any[]> {
     this.additionalSigned = this.#signedExtensions!.map((se) => se.additionalSigned);
   }
 
+  async fromPayload(payload: SignerPayloadJSON): Promise<void> {
+    this.#signedExtensions = this.#getSignedExtensions();
+
+    await Promise.all(this.#signedExtensions!.map((se) => se.fromPayload(payload)));
+
+    this.data = this.#signedExtensions!.map((se) => se.data);
+    this.additionalSigned = this.#signedExtensions!.map((se) => se.additionalSigned);
+  }
+
   get identifier(): string {
     return 'ExtraSignedExtension';
   }

--- a/packages/api/src/extrinsic/extensions/ExtraSignedExtension.ts
+++ b/packages/api/src/extrinsic/extensions/ExtraSignedExtension.ts
@@ -95,7 +95,7 @@ export class ExtraSignedExtension extends SignedExtension<any[], any[]> {
     );
   }
 
-  toPayload(call: HexString = '0x'): SignerPayloadJSON {
+  toPayload(call: HexString | string = '0x'): SignerPayloadJSON {
     const signedExtensions = this.#signedExtensions!.map((se) => se.identifier);
     const { version } = this.registry.metadata.extrinsic;
     const { signerAddress } = this.options!;
@@ -112,7 +112,7 @@ export class ExtraSignedExtension extends SignedExtension<any[], any[]> {
     ) as SignerPayloadJSON;
   }
 
-  toRawPayload(call: HexString = '0x'): SignerPayloadRaw {
+  toRawPayload(call: HexString | string = '0x'): SignerPayloadRaw {
     const payload = this.toPayload(call);
     const $ToSignPayload = $.Tuple($.RawHex, this.$Data, this.$AdditionalSigned);
     const toSignPayload = [call, this.data, this.additionalSigned];

--- a/packages/api/src/extrinsic/extensions/FallbackSignedExtension.ts
+++ b/packages/api/src/extrinsic/extensions/FallbackSignedExtension.ts
@@ -1,12 +1,12 @@
 import { PortableRegistry } from '@dedot/codecs';
 import { SignerPayloadJSON } from '@dedot/types';
-import { SignedExtension } from './SignedExtension.js';
 import { ISubstrateClient } from '../../types.js';
+import { SignedExtension } from './SignedExtension.js';
 
 /**
  * A fallback signed extension that can be used for extensions
  * that don't require external input.
- * 
+ *
  * This extension is automatically used for:
  * - Unknown extensions with empty struct or tuple types
  * - Known extensions that don't require input, such as:
@@ -14,17 +14,13 @@ import { ISubstrateClient } from '../../types.js';
  *   - CheckWeight: Block resource (weight) limit check
  *   - PrevalidateAttests: Validates `attest` calls prior to execution
  *   - StorageWeightReclaim: Storage weight reclaim mechanism
- * 
+ *
  * These extensions have empty struct or tuple types and don't need explicit implementation.
  */
 export class FallbackSignedExtension extends SignedExtension {
   private readonly extensionIdent: string;
 
-  constructor(
-    client: ISubstrateClient,
-    options: any,
-    extensionIdent: string
-  ) {
+  constructor(client: ISubstrateClient, options: any, extensionIdent: string) {
     super(client, options);
     this.extensionIdent = extensionIdent;
   }
@@ -39,6 +35,11 @@ export class FallbackSignedExtension extends SignedExtension {
     this.additionalSigned = [];
   }
 
+  async fromPayload(_: SignerPayloadJSON): Promise<void> {
+    this.data = {};
+    this.additionalSigned = [];
+  }
+
   toPayload(): Partial<SignerPayloadJSON> {
     return {}; // No payload contribution
   }
@@ -46,7 +47,7 @@ export class FallbackSignedExtension extends SignedExtension {
 
 /**
  * Checks if a type is an empty struct or tuple (doesn't require external input).
- * 
+ *
  * @param registry The portable registry
  * @param typeId The type ID to check
  * @returns True if the type is an empty struct or tuple, false otherwise
@@ -54,12 +55,12 @@ export class FallbackSignedExtension extends SignedExtension {
 export function isEmptyStructOrTuple(registry: PortableRegistry, typeId: number): boolean {
   try {
     const type = registry.findType(typeId);
-    
+
     // Check if it's an empty struct
     if (type.typeDef.type === 'Struct' && type.typeDef.value.fields.length === 0) {
       return true;
     }
-    
+
     // Check if it's an empty tuple
     if (type.typeDef.type === 'Tuple' && type.typeDef.value.fields.length === 0) {
       return true;
@@ -67,7 +68,7 @@ export function isEmptyStructOrTuple(registry: PortableRegistry, typeId: number)
   } catch (error) {
     // Ignore errors
   }
-  
+
   // All other cases (including errors) require input
   return false;
 }

--- a/packages/api/src/extrinsic/extensions/SignedExtension.ts
+++ b/packages/api/src/extrinsic/extensions/SignedExtension.ts
@@ -1,7 +1,7 @@
 import { PortableRegistry, SignedExtensionDefLatest } from '@dedot/codecs';
 import * as $ from '@dedot/shape';
 import { PayloadOptions, SignerPayloadJSON } from '@dedot/types';
-import { ensurePresence } from '@dedot/utils';
+import { DedotError, ensurePresence } from '@dedot/utils';
 import { ISubstrateClient } from '../../types.js';
 
 export interface ISignedExtension {
@@ -12,6 +12,7 @@ export interface ISignedExtension {
   data: any;
   additionalSigned: any;
   init(): Promise<void>;
+  fromPayload(payload: SignerPayloadJSON): Promise<void>;
   registry: PortableRegistry;
   toPayload(...additional: any[]): Partial<SignerPayloadJSON>;
 }
@@ -37,7 +38,11 @@ export abstract class SignedExtension<Data extends any = {}, AdditionalSigned ex
   }
 
   async init() {
-    // TODO implement this method
+    throw new DedotError('Unimplemented');
+  }
+
+  async fromPayload(payload: SignerPayloadJSON): Promise<void> {
+    throw new DedotError('Unimplemented');
   }
 
   get identifier(): string {

--- a/packages/api/src/extrinsic/extensions/known/ChargeAssetTxPayment.ts
+++ b/packages/api/src/extrinsic/extensions/known/ChargeAssetTxPayment.ts
@@ -1,5 +1,5 @@
 import { SignerPayloadJSON } from '@dedot/types';
-import { assert, bnToHex, u8aToHex } from '@dedot/utils';
+import { assert, bnToHex, HexString, hexToBn, u8aToHex } from '@dedot/utils';
 import { SignedExtension } from '../SignedExtension.js';
 
 /**
@@ -12,6 +12,15 @@ export class ChargeAssetTxPayment extends SignedExtension<{ tip: bigint; assetId
     this.data = {
       tip: tip || 0n,
       assetId,
+    };
+  }
+
+  async fromPayload(payload: SignerPayloadJSON): Promise<void> {
+    const { tip, assetId } = payload;
+
+    this.data = {
+      tip: hexToBn(tip) || 0n,
+      assetId: this.#decodeAssetId(assetId),
     };
   }
 
@@ -31,6 +40,15 @@ export class ChargeAssetTxPayment extends SignedExtension<{ tip: bigint; assetId
     }
 
     return u8aToHex(this.$AssetId().tryEncode(assetId));
+  }
+
+  #decodeAssetId(assetId?: HexString): number | object | undefined {
+    // @ts-ignore
+    if (assetId === null || assetId === undefined || assetId === '' || assetId === '0x') {
+      return undefined;
+    }
+
+    return this.$AssetId().tryDecode(assetId);
   }
 
   $AssetId() {

--- a/packages/api/src/extrinsic/extensions/known/ChargeTransactionPayment.ts
+++ b/packages/api/src/extrinsic/extensions/known/ChargeTransactionPayment.ts
@@ -1,10 +1,16 @@
 import { SignerPayloadJSON } from '@dedot/types';
-import { bnToHex } from '@dedot/utils';
+import { bnToHex, hexToBn } from '@dedot/utils';
 import { SignedExtension } from '../SignedExtension.js';
 
 export class ChargeTransactionPayment extends SignedExtension<bigint> {
   async init(): Promise<void> {
     this.data = this.payloadOptions.tip || 0n;
+  }
+
+  async fromPayload(payload: SignerPayloadJSON): Promise<void> {
+    const { tip } = payload;
+
+    this.data = hexToBn(tip) || 0n;
   }
 
   toPayload(): Partial<SignerPayloadJSON> {

--- a/packages/api/src/extrinsic/extensions/known/CheckGenesis.ts
+++ b/packages/api/src/extrinsic/extensions/known/CheckGenesis.ts
@@ -11,6 +11,10 @@ export class CheckGenesis extends SignedExtension<{}, Hash> {
     this.additionalSigned = ensurePresence(this.client.genesisHash);
   }
 
+  async fromPayload(payload: SignerPayloadJSON): Promise<void> {
+    this.additionalSigned = ensurePresence(payload.genesisHash, 'Genesis hash not found in the payload');
+  }
+
   toPayload(): Partial<SignerPayloadJSON> {
     return {
       genesisHash: this.additionalSigned,

--- a/packages/api/src/extrinsic/extensions/known/CheckMetadataHash.ts
+++ b/packages/api/src/extrinsic/extensions/known/CheckMetadataHash.ts
@@ -1,6 +1,6 @@
 import { Hash } from '@dedot/codecs';
 import { SignerPayloadJSON } from '@dedot/types';
-import { assert, isHex } from '@dedot/utils';
+import { assert, ensurePresence, isHex } from '@dedot/utils';
 import { SignedExtension } from '../SignedExtension.js';
 
 export type CheckMetadataHashMode = 'Disabled' | 'Enabled';
@@ -13,6 +13,19 @@ export class CheckMetadataHash extends SignedExtension<{ mode: CheckMetadataHash
     let metadataHash = this.payloadOptions.metadataHash;
 
     if (metadataHash) {
+      assert(isHex(metadataHash), 'Metadata hash is not a valid hex string');
+      this.data = { mode: 'Enabled' };
+      this.additionalSigned = metadataHash;
+    } else {
+      this.data = { mode: 'Disabled' };
+      this.additionalSigned = undefined;
+    }
+  }
+
+  async fromPayload(payload: SignerPayloadJSON): Promise<void> {
+    const { mode, metadataHash } = payload;
+
+    if (mode) {
       assert(isHex(metadataHash), 'Metadata hash is not a valid hex string');
       this.data = { mode: 'Enabled' };
       this.additionalSigned = metadataHash;

--- a/packages/api/src/extrinsic/extensions/known/CheckMortality.ts
+++ b/packages/api/src/extrinsic/extensions/known/CheckMortality.ts
@@ -1,6 +1,6 @@
 import { BlockHash, EraLike, Hash, Header } from '@dedot/codecs';
 import { SignerPayloadJSON } from '@dedot/types';
-import { assert, bnMin, isZeroHex, numberToHex, u8aToHex } from '@dedot/utils';
+import { assert, bnMin, hexToBn, hexToNumber, isZeroHex, numberToHex, u8aToHex } from '@dedot/utils';
 import { DedotClient } from '../../../client/index.js';
 import { SignedExtension } from '../SignedExtension.js';
 
@@ -24,6 +24,14 @@ export class CheckMortality extends SignedExtension<EraLike, Hash> {
     this.#signingHeader = await this.#getSigningHeader();
     this.data = { period: this.#calculateMortalLength(), current: BigInt(this.#signingHeader.number) };
     this.additionalSigned = this.#signingHeader.hash;
+  }
+
+  async fromPayload(payload: SignerPayloadJSON): Promise<void> {
+    const { era, blockHash, blockNumber } = payload;
+
+    this.#signingHeader = { hash: blockHash, number: hexToNumber(blockNumber) };
+    this.data = this.$Data.tryDecode(era) as EraLike;
+    this.additionalSigned = blockHash;
   }
 
   async #getSigningHeader(): Promise<SigningHeader> {

--- a/packages/api/src/extrinsic/extensions/known/CheckNonce.ts
+++ b/packages/api/src/extrinsic/extensions/known/CheckNonce.ts
@@ -1,4 +1,3 @@
-import { EraLike } from '@dedot/codecs';
 import { SignerPayloadJSON } from '@dedot/types';
 import { assert, hexToNumber, numberToHex } from '@dedot/utils';
 import { SignedExtension } from '../SignedExtension.js';

--- a/packages/api/src/extrinsic/extensions/known/CheckNonce.ts
+++ b/packages/api/src/extrinsic/extensions/known/CheckNonce.ts
@@ -1,5 +1,6 @@
+import { EraLike } from '@dedot/codecs';
 import { SignerPayloadJSON } from '@dedot/types';
-import { assert, numberToHex } from '@dedot/utils';
+import { assert, hexToNumber, numberToHex } from '@dedot/utils';
 import { SignedExtension } from '../SignedExtension.js';
 
 /**
@@ -8,6 +9,12 @@ import { SignedExtension } from '../SignedExtension.js';
 export class CheckNonce extends SignedExtension<number> {
   async init(): Promise<void> {
     this.data = this.payloadOptions.nonce || (await this.#getNonce());
+  }
+
+  async fromPayload(payload: SignerPayloadJSON): Promise<void> {
+    const { nonce } = payload;
+
+    this.data = hexToNumber(nonce);
   }
 
   async #getNonce(): Promise<number> {

--- a/packages/api/src/extrinsic/extensions/known/CheckSpecVersion.ts
+++ b/packages/api/src/extrinsic/extensions/known/CheckSpecVersion.ts
@@ -1,5 +1,5 @@
 import { SignerPayloadJSON } from '@dedot/types';
-import { numberToHex } from '@dedot/utils';
+import { hexToNumber, numberToHex } from '@dedot/utils';
 import { SignedExtension } from '../SignedExtension.js';
 
 /**
@@ -8,6 +8,12 @@ import { SignedExtension } from '../SignedExtension.js';
 export class CheckSpecVersion extends SignedExtension<{}, number> {
   async init(): Promise<void> {
     this.additionalSigned = this.client.runtimeVersion.specVersion;
+  }
+
+  async fromPayload(payload: SignerPayloadJSON): Promise<void> {
+    const { specVersion } = payload;
+
+    this.additionalSigned = hexToNumber(specVersion);
   }
 
   toPayload(): Partial<SignerPayloadJSON> {

--- a/packages/api/src/extrinsic/extensions/known/CheckTxVersion.ts
+++ b/packages/api/src/extrinsic/extensions/known/CheckTxVersion.ts
@@ -1,5 +1,5 @@
 import { SignerPayloadJSON } from '@dedot/types';
-import { numberToHex } from '@dedot/utils';
+import { hexToNumber, numberToHex } from '@dedot/utils';
 import { SignedExtension } from '../SignedExtension.js';
 
 /**
@@ -8,6 +8,12 @@ import { SignedExtension } from '../SignedExtension.js';
 export class CheckTxVersion extends SignedExtension<{}, number> {
   async init(): Promise<void> {
     this.additionalSigned = this.client.runtimeVersion.transactionVersion;
+  }
+
+  async fromPayload(payload: SignerPayloadJSON): Promise<void> {
+    const { transactionVersion } = payload;
+
+    this.additionalSigned = hexToNumber(transactionVersion);
   }
 
   toPayload(): Partial<SignerPayloadJSON> {

--- a/packages/api/src/extrinsic/submittable/BaseSubmittableExtrinsic.ts
+++ b/packages/api/src/extrinsic/submittable/BaseSubmittableExtrinsic.ts
@@ -18,7 +18,7 @@ import type { FrameSystemEventRecord, SubstrateApi } from '../../chaintypes/inde
 import type { ISubstrateClient, ISubstrateClientAt } from '../../types.js';
 import { ExtraSignedExtension } from '../extensions/index.js';
 import { fakeSigner } from './fakeSigner.js';
-import { isKeyringPair, signRaw, txDefer } from './utils.js';
+import { isKeyringPair, signRawMessage, txDefer } from './utils.js';
 
 export abstract class BaseSubmittableExtrinsic extends Extrinsic implements ISubmittableExtrinsic {
   #alterTx?: HexString;
@@ -52,7 +52,7 @@ export abstract class BaseSubmittableExtrinsic extends Extrinsic implements ISub
 
     let signature: HexString, alteredTx: HexString | Uint8Array | undefined;
     if (isKeyringPair(fromAccount)) {
-      signature = u8aToHex(signRaw(fromAccount, extra.toRawPayload(this.callHex).data as HexString));
+      signature = u8aToHex(signRawMessage(fromAccount, extra.toRawPayload(this.callHex).data as HexString));
     } else if (signer?.signPayload) {
       const result = await signer.signPayload(extra.toPayload(this.callHex));
 

--- a/packages/api/src/extrinsic/submittable/index.ts
+++ b/packages/api/src/extrinsic/submittable/index.ts
@@ -2,3 +2,4 @@ export * from './errors.js';
 export * from './SubmittableResult.js';
 export * from './SubmittableExtrinsic.js';
 export * from './SubmittableExtrinsicV2.js';
+export { signRawMessage } from './utils.js';

--- a/packages/api/src/extrinsic/submittable/utils.ts
+++ b/packages/api/src/extrinsic/submittable/utils.ts
@@ -12,7 +12,7 @@ export function isKeyringPair(account: AddressOrPair): account is IKeyringPair {
  * @param signerPair
  * @param raw
  */
-export function signRaw(signerPair: IKeyringPair, raw: HexString): Uint8Array {
+export function signRawMessage(signerPair: IKeyringPair, raw: HexString | string): Uint8Array {
   const u8a = hexToU8a(raw);
   // Ref: https://github.com/paritytech/polkadot-sdk/blob/943697fa693a4da6ef481ef93df522accb7d0583/substrate/primitives/runtime/src/generic/unchecked_extrinsic.rs#L234-L238
   const toSignRaw = u8a.length > 256 ? blake2AsU8a(u8a, 256) : u8a;

--- a/packages/utils/src/__tests__/hex.spec.ts
+++ b/packages/utils/src/__tests__/hex.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { hexToString, hexToU8a, isZeroHex } from '../hex.js';
+import { hexToString, hexToU8a, isZeroHex, hexToNumber, hexToBn } from '../hex.js';
 import { HexString } from '../types.js';
 
 describe('hex', () => {
@@ -40,6 +40,114 @@ describe('hex', () => {
       { input: '0x11223344', expected: false },
     ])('should check zero hex for $input', ({ input, expected }) => {
       expect(isZeroHex(input as HexString)).toEqual(expected);
+    });
+  });
+
+  describe('hexToNumber', () => {
+    it.each([
+      { input: '0x0', expected: 0 },
+      { input: '0x1', expected: 1 },
+      { input: '0xa', expected: 10 },
+      { input: '0xff', expected: 255 },
+      { input: '0x1a', expected: 26 },
+      { input: '0x123', expected: 291 },
+      { input: '0x123abc', expected: 1194684 },
+      { input: '0xffffffff', expected: 4294967295 },
+    ])('should convert hex string with 0x prefix: $input -> $expected', ({ input, expected }) => {
+      expect(hexToNumber(input)).toBe(expected);
+    });
+
+    it.each([
+      { input: '0', expected: 0 },
+      { input: '1', expected: 1 },
+      { input: 'a', expected: 10 },
+      { input: 'ff', expected: 255 },
+      { input: '1a', expected: 26 },
+      { input: '123', expected: 291 },
+      { input: '123abc', expected: 1194684 },
+      { input: 'ffffffff', expected: 4294967295 },
+    ])('should convert hex string without 0x prefix: $input -> $expected', ({ input, expected }) => {
+      expect(hexToNumber(input)).toBe(expected);
+    });
+
+    it.each([
+      { input: undefined, expected: 0 },
+      { input: '', expected: 0 },
+      { input: '0x', expected: 0 },
+    ])('should handle edge cases: $input -> $expected', ({ input, expected }) => {
+      expect(hexToNumber(input)).toBe(expected);
+    });
+
+    it('should handle uppercase hex letters', () => {
+      expect(hexToNumber('0xABCDEF')).toBe(11259375);
+      expect(hexToNumber('ABCDEF')).toBe(11259375);
+    });
+
+    it('should handle mixed case hex letters', () => {
+      expect(hexToNumber('0xAbCdEf')).toBe(11259375);
+      expect(hexToNumber('AbCdEf')).toBe(11259375);
+    });
+  });
+
+  describe('hexToBn', () => {
+    it.each([
+      { input: '0x0', expected: 0n },
+      { input: '0x1', expected: 1n },
+      { input: '0xa', expected: 10n },
+      { input: '0xff', expected: 255n },
+      { input: '0x1a', expected: 26n },
+      { input: '0x123', expected: 291n },
+      { input: '0x123abc', expected: 1194684n },
+      { input: '0xffffffff', expected: 4294967295n },
+    ])('should convert hex string with 0x prefix: $input -> $expected', ({ input, expected }) => {
+      expect(hexToBn(input as HexString)).toBe(expected);
+    });
+
+    it.each([
+      { input: '0x0', expected: 0n },
+      { input: '0x1', expected: 1n },
+      { input: '0xa', expected: 10n },
+      { input: '0xff', expected: 255n },
+      { input: '0x1a', expected: 26n },
+      { input: '0x123', expected: 291n },
+      { input: '0x123abc', expected: 1194684n },
+      { input: '0xffffffff', expected: 4294967295n },
+    ])('should convert hex string without 0x prefix by handling it internally: $input -> $expected', ({ input, expected }) => {
+      // Note: hexToBn expects HexString type (with 0x prefix), but internally uses hexStripPrefix
+      expect(hexToBn(input as HexString)).toBe(expected);
+    });
+
+    it.each([
+      { input: undefined, expected: 0n },
+      { input: '0x' as HexString, expected: 0n },
+    ])('should handle edge cases: $input -> $expected', ({ input, expected }) => {
+      expect(hexToBn(input)).toBe(expected);
+    });
+
+    it('should handle large numbers beyond JavaScript safe integer limit', () => {
+      const largeHex = '0x1fffffffffffff' as HexString; // Larger than Number.MAX_SAFE_INTEGER
+      const expected = 9007199254740991n;
+      expect(hexToBn(largeHex)).toBe(expected);
+    });
+
+    it('should handle very large numbers', () => {
+      const veryLargeHex = '0x123456789abcdef0123456789abcdef' as HexString;
+      const expected = BigInt('0x123456789abcdef0123456789abcdef');
+      expect(hexToBn(veryLargeHex)).toBe(expected);
+    });
+
+    it('should handle uppercase hex letters', () => {
+      expect(hexToBn('0xABCDEF' as HexString)).toBe(11259375n);
+    });
+
+    it('should handle mixed case hex letters', () => {
+      expect(hexToBn('0xAbCdEf' as HexString)).toBe(11259375n);
+    });
+
+    it('should handle 256-bit numbers', () => {
+      const hex256 = '0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff' as HexString;
+      const expected = BigInt('0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff');
+      expect(hexToBn(hex256)).toBe(expected);
     });
   });
 });

--- a/packages/utils/src/hex.ts
+++ b/packages/utils/src/hex.ts
@@ -57,14 +57,22 @@ export const hexStripPrefix = (input?: HexString | string): string => {
   return input.startsWith('0x') ? input.substring(2) : input;
 };
 
-export const hexToNumber = (input?: string): number => {
-  if (!input) return 0;
-
-  return parseInt(hexStripPrefix(input), 16);
+/**
+ * Convert a hex string to a number
+ *
+ * @param input
+ */
+export const hexToNumber = (input?: HexString | string): number => {
+  const stripped = hexStripPrefix(input);
+  return stripped ? parseInt(stripped, 16) : 0;
 };
 
-export const hexToBn = (input?: HexString): bigint => {
-  if (!input) return 0n;
-
-  return BigInt(`0x${hexStripPrefix(input)}`);
+/**
+ * Convert a hex string to a bigint
+ *
+ * @param input
+ */
+export const hexToBn = (input?: HexString | string): bigint => {
+  const stripped = hexStripPrefix(input);
+  return stripped ? BigInt(`0x${stripped}`) : 0n;
 };

--- a/packages/utils/src/hex.ts
+++ b/packages/utils/src/hex.ts
@@ -57,5 +57,14 @@ export const hexStripPrefix = (input?: HexString | string): string => {
   return input.startsWith('0x') ? input.substring(2) : input;
 };
 
-// - TODO hexToNumber
-// - TODO hexToBigInt
+export const hexToNumber = (input?: string): number => {
+  if (!input) return 0;
+
+  return parseInt(hexStripPrefix(input), 16);
+};
+
+export const hexToBn = (input?: HexString): bigint => {
+  if (!input) return 0n;
+
+  return BigInt(`0x${hexStripPrefix(input)}`);
+};


### PR DESCRIPTION
Add a helper into the `ExtraSignedExtension` to allow convert json payload to raw payload for siging purposes.

```ts
import { DedotClient, ExtraSignedExtension, signRawMessage, WsProvider } from 'dedot';
import { SignerPayloadJSON, SignerResult } from 'dedot/types';
import { u8aToHex } from 'dedot/utils';

const payload: SignerPayloadJSON = { ... };

const extra = new ExtraSignedExtension(client, { signerAddress: payload.address });
await extra.fromPayload(payload);

const rawPayload = extra.toRawPayload(payload.method as HexString).data;
const signature = u8aToHex(signRawMessage(alice, rawPayload));
```