### PR TITLE
feat(contracts): expose module errors

### DIFF
--- a/e2e/contracts/src/tests/errors.test.ts
+++ b/e2e/contracts/src/tests/errors.test.ts
@@ -46,9 +46,15 @@ describe('Errors', () => {
         .signAndSend(alicePair)
         .untilFinalized();
 
-      await expect(deployer.query.newDefault({ gasLimit: raw.gasRequired, salt })).rejects.toThrowError(
-        ContractInstantiateDispatchError,
-      );
+      try {
+        await deployer.query.newDefault({ gasLimit: raw.gasRequired, salt });
+      } catch (e: any) {
+        expect(e).toBeInstanceOf(ContractInstantiateDispatchError);
+        expect(e.moduleError).toBeDefined();
+        expect(e.moduleError!.pallet).toEqual('Contracts');
+        expect(e.moduleError!.name).toEqual('DuplicateContract');
+        expect(e.message).toMatch(/Dispatch error: Contracts::DuplicateContract/);
+      }
     });
 
     it('should throw ContractInstantiateLangError', async () => {

--- a/packages/codecs/src/registry/__tests__/PortableRegistry.spec.ts
+++ b/packages/codecs/src/registry/__tests__/PortableRegistry.spec.ts
@@ -52,5 +52,31 @@ describe('PortableRegistry', () => {
         expect(() => registry.findType(1_000_000)).toThrowError('Cannot find portable type for id: 1000000');
       });
     });
+
+    describe('findErrorMeta', () => {
+      it('should return undefined for non-module dispatch error', () => {
+        const dispatchError = { type: 'Other' } as any;
+        expect(registry.findErrorMeta(dispatchError)).toBeUndefined();
+      });
+
+      it('should return error metadata for a valid module error', () => {
+        const moduleError = { index: 10, error: '0x04000000' as const }; // PalletId 10, ErrorId 4
+        const errorMeta = registry.findErrorMeta(moduleError);
+
+        expect(errorMeta).toBeDefined();
+        expect(errorMeta!.pallet).toEqual('ElectionProviderMultiPhase');
+        expect(errorMeta!.name).toEqual('SignedCannotPayDeposit');
+      });
+
+      it('should return undefined for a non-existent pallet index', () => {
+        const moduleError = { index: 999, error: '0x00' as const };
+        expect(registry.findErrorMeta(moduleError)).toBeUndefined();
+      });
+
+      it('should return undefined for a non-existent error index within a pallet', () => {
+        const moduleError = { index: 10, error: '0x99' as const };
+        expect(registry.findErrorMeta(moduleError)).toBeUndefined();
+      });
+    });
   });
 });

--- a/packages/contracts/src/__tests__/errors.spec.ts
+++ b/packages/contracts/src/__tests__/errors.spec.ts
@@ -18,7 +18,7 @@ describe('Dispatch Errors', () => {
   describe('ContractInstantiateDispatchError', () => {
     it('should format the message with module error details when provided', () => {
       const error = new ContractInstantiateDispatchError(mockDispatchError, mockRawResult, mockModuleError);
-      expect(error.message).toBe('Dispatch error: TestPallet::TestError\n  This is a test error.');
+      expect(error.message).toBe('Dispatch error: TestPallet::TestError - This is a test error.');
       expect(error.moduleError).toBe(mockModuleError);
     });
 
@@ -32,7 +32,7 @@ describe('Dispatch Errors', () => {
   describe('ContractDispatchError', () => {
     it('should format the message with module error details when provided', () => {
       const error = new ContractDispatchError(mockDispatchError, mockRawResult, mockModuleError);
-      expect(error.message).toBe('Dispatch error: TestPallet::TestError\n  This is a test error.');
+      expect(error.message).toBe('Dispatch error: TestPallet::TestError - This is a test error.');
       expect(error.moduleError).toBe(mockModuleError);
     });
 

--- a/packages/contracts/src/__tests__/errors.spec.ts
+++ b/packages/contracts/src/__tests__/errors.spec.ts
@@ -1,0 +1,45 @@
+import { PalletErrorMetadataLatest } from '@dedot/codecs';
+import { describe, expect, it } from 'vitest';
+import { ContractDispatchError, ContractInstantiateDispatchError } from '../errors';
+
+describe('Dispatch Errors', () => {
+  const mockDispatchError = { type: 'Module', value: { index: 1, error: '0x00' } } as any;
+  const mockRawResult = {} as any;
+  const mockModuleError: PalletErrorMetadataLatest = {
+    pallet: 'TestPallet',
+    name: 'TestError',
+    docs: ['This is a test error.'],
+    fields: [],
+    index: 0,
+    fieldCodecs: [],
+    palletIndex: 0,
+  };
+
+  describe('ContractInstantiateDispatchError', () => {
+    it('should format the message with module error details when provided', () => {
+      const error = new ContractInstantiateDispatchError(mockDispatchError, mockRawResult, mockModuleError);
+      expect(error.message).toBe('Dispatch error: TestPallet::TestError\n  This is a test error.');
+      expect(error.moduleError).toBe(mockModuleError);
+    });
+
+    it('should use JSON.stringify for the message when module error is not provided', () => {
+      const error = new ContractInstantiateDispatchError(mockDispatchError, mockRawResult);
+      expect(error.message).toBe(`Dispatch error: ${JSON.stringify(mockDispatchError)}`);
+      expect(error.moduleError).toBeUndefined();
+    });
+  });
+
+  describe('ContractDispatchError', () => {
+    it('should format the message with module error details when provided', () => {
+      const error = new ContractDispatchError(mockDispatchError, mockRawResult, mockModuleError);
+      expect(error.message).toBe('Dispatch error: TestPallet::TestError\n  This is a test error.');
+      expect(error.moduleError).toBe(mockModuleError);
+    });
+
+    it('should use JSON.stringify for the message when module error is not provided', () => {
+      const error = new ContractDispatchError(mockDispatchError, mockRawResult);
+      expect(error.message).toBe(`Dispatch error: ${JSON.stringify(mockDispatchError)}`);
+      expect(error.moduleError).toBeUndefined();
+    });
+  });
+});

--- a/packages/contracts/src/errors.ts
+++ b/packages/contracts/src/errors.ts
@@ -1,4 +1,4 @@
-import { DispatchError } from '@dedot/codecs';
+import { DispatchError, PalletErrorMetadataLatest } from '@dedot/codecs';
 import { assert, DedotError } from '@dedot/utils';
 import { ContractCallResult, ContractInstantiateResult, GenericContractApi, ReturnFlags } from './types/index.js';
 import { toReturnFlags } from './utils/index.js';
@@ -45,17 +45,35 @@ export class ContractInstantiateDispatchError<
    * The error that occurred during the dispatch phase.
    */
   dispatchError: DispatchError;
+  /**
+   * The decoded module error, if any.
+   */
+  moduleError?: PalletErrorMetadataLatest;
 
   /**
    * Constructs a new `ContractInstantiateDispatchError` instance.
    *
    * @param err - The `DispatchError` that occurred during the dispatch phase.
    * @param raw - The raw result of the contract instantiation.
+   * @param moduleError - The decoded module error, if any.
    */
-  constructor(err: DispatchError, raw: ContractInstantiateResult<ContractApi['types']['ChainApi']>) {
+  constructor(
+    err: DispatchError,
+    raw: ContractInstantiateResult<ContractApi['types']['ChainApi']>,
+    moduleError?: PalletErrorMetadataLatest,
+  ) {
     super(raw);
     this.dispatchError = err;
-    this.message = `Dispatch error: ${JSON.stringify(err)}`;
+    this.moduleError = moduleError;
+    if (moduleError) {
+      const { pallet, name, docs } = moduleError;
+      this.message = `Dispatch error: ${pallet}::${name}`;
+      if (docs) {
+        this.message += `\n  ${docs.join('\n  ')}`;
+      }
+    } else {
+      this.message = `Dispatch error: ${JSON.stringify(err)}`;
+    }
   }
 }
 
@@ -143,17 +161,35 @@ export class ContractDispatchError<
    * The error that occurred during the dispatch phase.
    */
   dispatchError: DispatchError;
+  /**
+   * The decoded module error, if any.
+   */
+  moduleError?: PalletErrorMetadataLatest;
 
   /**
    * Constructs a new `ContractDispatchError` instance.
    *
    * @param err - The `DispatchError` that occurred during the dispatch phase.
    * @param raw - The raw result of the contract call.
+   * @param moduleError - The decoded module error, if any.
    */
-  constructor(err: DispatchError, raw: ContractCallResult<ContractApi['types']['ChainApi']>) {
+  constructor(
+    err: DispatchError,
+    raw: ContractCallResult<ContractApi['types']['ChainApi']>,
+    moduleError?: PalletErrorMetadataLatest,
+  ) {
     super(raw);
     this.dispatchError = err;
-    this.message = `Dispatch error: ${JSON.stringify(err)}`;
+    this.moduleError = moduleError;
+    if (moduleError) {
+      const { pallet, name, docs } = moduleError;
+      this.message = `Dispatch error: ${pallet}::${name}`;
+      if (docs) {
+        this.message += `\n  ${docs.join('\n  ')}`;
+      }
+    } else {
+      this.message = `Dispatch error: ${JSON.stringify(err)}`;
+    }
   }
 }
 

--- a/packages/contracts/src/errors.ts
+++ b/packages/contracts/src/errors.ts
@@ -8,7 +8,7 @@ const formatDispatchError = (err: DispatchError, moduleError?: PalletErrorMetada
     const { pallet, name, docs } = moduleError;
     let message = `Dispatch error: ${pallet}::${name}`;
     if (docs) {
-      message += `- ${docs.join('\n  ')}`;
+      message += ` - ${docs.join('\n  ')}`;
     }
     return message;
   } else {

--- a/packages/contracts/src/errors.ts
+++ b/packages/contracts/src/errors.ts
@@ -3,6 +3,19 @@ import { assert, DedotError } from '@dedot/utils';
 import { ContractCallResult, ContractInstantiateResult, GenericContractApi, ReturnFlags } from './types/index.js';
 import { toReturnFlags } from './utils/index.js';
 
+const formatDispatchError = (err: DispatchError, moduleError?: PalletErrorMetadataLatest) => {
+  if (moduleError) {
+    const { pallet, name, docs } = moduleError;
+    let message = `Dispatch error: ${pallet}::${name}`;
+    if (docs) {
+      message += `\n  ${docs.join('\n  ')}`;
+    }
+    return message;
+  } else {
+    return `Dispatch error: ${JSON.stringify(err)}`;
+  }
+};
+
 /**
  * Represents an error that occurred during the instantiation of a smart contract.
  * This class extends the base `DedotError` and includes a `raw` property of type `ContractInstantiateResult`.
@@ -65,15 +78,7 @@ export class ContractInstantiateDispatchError<
     super(raw);
     this.dispatchError = err;
     this.moduleError = moduleError;
-    if (moduleError) {
-      const { pallet, name, docs } = moduleError;
-      this.message = `Dispatch error: ${pallet}::${name}`;
-      if (docs) {
-        this.message += `\n  ${docs.join('\n  ')}`;
-      }
-    } else {
-      this.message = `Dispatch error: ${JSON.stringify(err)}`;
-    }
+    this.message = formatDispatchError(err, moduleError);
   }
 }
 
@@ -181,15 +186,7 @@ export class ContractDispatchError<
     super(raw);
     this.dispatchError = err;
     this.moduleError = moduleError;
-    if (moduleError) {
-      const { pallet, name, docs } = moduleError;
-      this.message = `Dispatch error: ${pallet}::${name}`;
-      if (docs) {
-        this.message += `\n  ${docs.join('\n  ')}`;
-      }
-    } else {
-      this.message = `Dispatch error: ${JSON.stringify(err)}`;
-    }
+    this.message = formatDispatchError(err, moduleError);
   }
 }
 

--- a/packages/contracts/src/errors.ts
+++ b/packages/contracts/src/errors.ts
@@ -8,7 +8,7 @@ const formatDispatchError = (err: DispatchError, moduleError?: PalletErrorMetada
     const { pallet, name, docs } = moduleError;
     let message = `Dispatch error: ${pallet}::${name}`;
     if (docs) {
-      message += `\n  ${docs.join('\n  ')}`;
+      message += `- ${docs.join('\n  ')}`;
     }
     return message;
   } else {

--- a/packages/contracts/src/executor/ConstructorQueryExecutor.ts
+++ b/packages/contracts/src/executor/ConstructorQueryExecutor.ts
@@ -108,7 +108,9 @@ export class ConstructorQueryExecutor<ChainApi extends GenericSubstrateApi> exte
       })();
 
       if (raw.result.isErr) {
-        throw new ContractInstantiateDispatchError(raw.result.err, raw);
+        const dispatchError = raw.result.err;
+        const moduleError = client.registry.findErrorMeta(dispatchError);
+        throw new ContractInstantiateDispatchError(dispatchError, raw, moduleError);
       }
 
       const data = this.tryDecode(meta, raw.result.value.result.data) as Result<any, any>;

--- a/packages/contracts/src/executor/QueryExecutor.ts
+++ b/packages/contracts/src/executor/QueryExecutor.ts
@@ -72,7 +72,9 @@ export class QueryExecutor<ChainApi extends GenericSubstrateApi> extends Contrac
       })();
 
       if (raw.result.isErr) {
-        throw new ContractDispatchError(raw.result.err, raw);
+        const dispatchError = raw.result.err;
+        const moduleError = client.registry.findErrorMeta(dispatchError);
+        throw new ContractDispatchError(dispatchError, raw, moduleError);
       }
 
       const data = this.tryDecode(meta, raw.result.value.data) as Result<any, any>;


### PR DESCRIPTION
Expose the detailed module error for contract's dispatch errors. Devs now don't have to manually call `client.registry.findErrorMeta` every time hitting a dispatch error.