### PR TITLE
fix: partial params type inference for storage entries method

### DIFF
--- a/examples/scripts/storage-entries.ts
+++ b/examples/scripts/storage-entries.ts
@@ -1,0 +1,18 @@
+import { PolkadotAssetHubApi } from '@dedot/chaintypes';
+import { DedotClient, WsProvider } from 'dedot';
+
+const client = await DedotClient.new<PolkadotAssetHubApi>(new WsProvider('wss://polkadot-asset-hub-rpc.polkadot.io'));
+
+console.log('Start querying...');
+
+const allItems = await client.query.nfts.account.entries();
+console.log('All Items', allItems.length);
+
+const account = '15CoYMEnJhhWHvdEPXDuTBnZKXwrJzMQdcMwcHGsVx5kXYvW';
+const itemsByAccount = await client.query.nfts.account.entries(account);
+console.log('All Items By Account', itemsByAccount.length);
+
+const items = await client.query.nfts.account.entries(account, 452);
+console.log('All Items By Account & Collection', items.length);
+
+await client.disconnect();

--- a/packages/types/src/generic.ts
+++ b/packages/types/src/generic.ts
@@ -73,8 +73,32 @@ interface PagedEntriesMethod<T extends AnyFunc = AnyFunc, TypeOut extends any = 
 export type WithoutLast<T> = T extends any[] ? (T extends [...infer U, any] ? U : T) : T;
 
 export type WithPagination<T> = T extends any[]
-  ? [...Partial<WithoutLast<T>>, pagination?: PaginationOptions]
+  ? [...PartialParams<WithoutLast<T>>, pagination?: PaginationOptions]
   : [pagination?: PaginationOptions];
+
+export type PartialParams<T> = T extends readonly [...infer Params]
+  ? Params extends readonly []
+    ? []
+    : Params extends readonly [infer P1]
+      ? [P1?]
+      : Params extends readonly [infer P1, infer P2]
+        ? [P1?] | [P1, P2?]
+        : Params extends readonly [infer P1, infer P2, infer P3]
+          ? [P1?] | [P1, P2?] | [P1, P2, P3?]
+          : Params extends readonly [infer P1, infer P2, infer P3, infer P4]
+            ? [P1?] | [P1, P2?] | [P1, P2, P3?] | [P1, P2, P3, P4?]
+            : Params extends readonly [infer P1, infer P2, infer P3, infer P4, infer P5]
+              ? [P1?] | [P1, P2?] | [P1, P2, P3?] | [P1, P2, P3, P4?] | [P1, P2, P3, P4, P5?]
+              : Params extends readonly [infer P1, infer P2, infer P3, infer P4, infer P5, infer P6]
+                ?
+                    | [P1?]
+                    | [P1, P2?]
+                    | [P1, P2, P3?]
+                    | [P1, P2, P3, P4?]
+                    | [P1, P2, P3, P4, P5?]
+                    | [P1, P2, P3, P4, P5, P6?]
+                : Partial<Params>
+  : [];
 
 /**
  * @description A generic type for storage query methods that handles both single and map (double & n-th map) storage entries
@@ -109,7 +133,7 @@ export type GenericStorageQuery<
           ? {
               /** Get all storage entries, allowing partial keys input */
               entries: (
-                ...args: WithoutLast<Parameters<T>[0]>
+                ...args: PartialParams<WithoutLast<Parameters<T>[0]>>
               ) => Promise<Array<[KeyTypeOut, NonNullable<ReturnType<T>>]>>;
             }
           : {


### PR DESCRIPTION
This is to fix the type inference for partial params of `.entries`  method for storage query.

Thanks @preschian for reporting this issue. 🙏