### PR TITLE
fix(api): make ISubstrateClientAt.atBlockHash prop non-optional

### DIFF
--- a/packages/api/src/executor/Executor.ts
+++ b/packages/api/src/executor/Executor.ts
@@ -1,7 +1,7 @@
 import type { BlockHash, PalletDefLatest } from '@dedot/codecs';
 import type { GenericSubstrateApi } from '@dedot/types';
 import { assert, HexString, stringCamelCase, UnknownApiError } from '@dedot/utils';
-import { ISubstrateClientAt } from '../types.js';
+import { ISubstrateClient, ISubstrateClientAt } from '../types.js';
 
 export interface StateCallParams {
   func: string;
@@ -17,13 +17,14 @@ export abstract class Executor<ChainApi extends GenericSubstrateApi = GenericSub
   readonly #atBlockHash?: BlockHash;
 
   constructor(
-    readonly client: ISubstrateClientAt<ChainApi>,
+    readonly client: ISubstrateClientAt<ChainApi> | ISubstrateClient<ChainApi, any>,
     atBlockHash?: BlockHash,
   ) {
     this.#atBlockHash = atBlockHash;
   }
 
   get atBlockHash() {
+    // @ts-ignore
     return this.#atBlockHash || this.client.atBlockHash;
   }
 

--- a/packages/api/src/executor/v2/RuntimeApiExecutorV2.ts
+++ b/packages/api/src/executor/v2/RuntimeApiExecutorV2.ts
@@ -2,7 +2,7 @@ import type { BlockHash } from '@dedot/codecs';
 import type { GenericSubstrateApi } from '@dedot/types';
 import { assert, HexString } from '@dedot/utils';
 import { ChainHead } from '../../json-rpc/index.js';
-import { ISubstrateClientAt } from '../../types.js';
+import { ISubstrateClient, ISubstrateClientAt } from '../../types.js';
 import { StateCallParams } from '../Executor.js';
 import { RuntimeApiExecutor } from '../RuntimeApiExecutor.js';
 
@@ -13,7 +13,7 @@ export class RuntimeApiExecutorV2<
   ChainApi extends GenericSubstrateApi = GenericSubstrateApi,
 > extends RuntimeApiExecutor<ChainApi> {
   constructor(
-    client: ISubstrateClientAt<ChainApi>,
+    client: ISubstrateClientAt<ChainApi> | ISubstrateClient<ChainApi, any>,
     public chainHead: ChainHead,
     atBlockHash?: BlockHash,
   ) {

--- a/packages/api/src/executor/v2/StorageQueryExecutorV2.ts
+++ b/packages/api/src/executor/v2/StorageQueryExecutorV2.ts
@@ -3,9 +3,8 @@ import type { AsyncMethod, GenericSubstrateApi, RpcVersion } from '@dedot/types'
 import { assert, HexString } from '@dedot/utils';
 import { ChainHead } from '../../json-rpc/index.js';
 import { type BaseStorageQuery, NewStorageQuery, QueryableStorage } from '../../storage/index.js';
-import { ISubstrateClientAt } from '../../types.js';
+import { ISubstrateClient, ISubstrateClientAt } from '../../types.js';
 import { StorageQueryExecutor } from '../StorageQueryExecutor.js';
-
 
 /**
  * @name StorageQueryExecutorV2
@@ -14,7 +13,7 @@ export class StorageQueryExecutorV2<
   ChainApi extends GenericSubstrateApi = GenericSubstrateApi,
 > extends StorageQueryExecutor<ChainApi> {
   constructor(
-    client: ISubstrateClientAt<ChainApi>,
+    client: ISubstrateClientAt<ChainApi> | ISubstrateClient<ChainApi, any>,
     public chainHead: ChainHead,
     atBlockHash?: BlockHash,
   ) {
@@ -31,9 +30,7 @@ export class StorageQueryExecutorV2<
       const withArgs = !!args && args.length > 0;
       const key = withArgs ? entry.encodeKey(args, true) : entry.prefixKey;
 
-      const results = await this.chainHead.storage([
-        { type: 'descendantsValues', key },
-      ]);
+      const results = await this.chainHead.storage([{ type: 'descendantsValues', key }]);
       return results.map(({ key, value }) => [
         entry.decodeKey(key as HexString),
         entry.decodeValue(value as HexString),

--- a/packages/api/src/executor/v2/ViewFunctionExecutorV2.ts
+++ b/packages/api/src/executor/v2/ViewFunctionExecutorV2.ts
@@ -1,7 +1,7 @@
 import type { GenericSubstrateApi } from '@dedot/types';
 import { assert, HexString } from '@dedot/utils';
 import { ChainHead } from '../../json-rpc/index.js';
-import { ISubstrateClientAt } from '../../types.js';
+import { ISubstrateClient, ISubstrateClientAt } from '../../types.js';
 import { StateCallParams } from '../Executor.js';
 import { ViewFunctionExecutor } from '../ViewFunctionExecutor.js';
 
@@ -12,7 +12,7 @@ export class ViewFunctionExecutorV2<
   ChainApi extends GenericSubstrateApi = GenericSubstrateApi,
 > extends ViewFunctionExecutor<ChainApi> {
   constructor(
-    client: ISubstrateClientAt<ChainApi>,
+    client: ISubstrateClientAt<ChainApi> | ISubstrateClient<ChainApi, any>,
     public chainHead: ChainHead,
   ) {
     assert(client.rpcVersion === 'v2', 'Only supports JSON-RPC v2');

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -108,10 +108,9 @@ export interface IJsonRpcClient<
 }
 
 /**
- * A generic interface for Substrate clients at a specific block
+ * @internal
  */
-export interface ISubstrateClientAt<ChainApi extends GenericSubstrateApi = GenericSubstrateApi> {
-  atBlockHash?: BlockHash;
+export interface IGenericSubstrateClient<ChainApi extends GenericSubstrateApi = GenericSubstrateApi> {
   rpcVersion: RpcVersion;
 
   options: ApiOptions;
@@ -130,13 +129,21 @@ export interface ISubstrateClientAt<ChainApi extends GenericSubstrateApi = Gener
 }
 
 /**
+ * A generic interface for Substrate clients at a specific block
+ */
+export interface ISubstrateClientAt<ChainApi extends GenericSubstrateApi = GenericSubstrateApi>
+  extends IGenericSubstrateClient<ChainApi> {
+  atBlockHash: BlockHash;
+}
+
+/**
  * A generic interface for Substrate clients
  */
 export interface ISubstrateClient<
   ChainApi extends GenericSubstrateApi = GenericSubstrateApi,
   Events extends string = ApiEvent,
 > extends IJsonRpcClient<ChainApi, Events>,
-    ISubstrateClientAt<ChainApi> {
+    IGenericSubstrateClient<ChainApi> {
   options: ApiOptions;
   tx: ChainApi['tx'];
 


### PR DESCRIPTION
Now the `ISubstrateClientAt.atBlockHash` prop should have only one type: `BlockHash`. No more optional.

```ts
const clientAt = client.at('0x...');
const hash: BlockHash = clientAt.atBlockHash;
```