### PR TITLE
fix: mismatch metadata on runtime upgrade

### DIFF
--- a/examples/scripts/decode-events-on-runtime-upgraded.ts
+++ b/examples/scripts/decode-events-on-runtime-upgraded.ts
@@ -1,0 +1,29 @@
+import { DedotClient, LegacyClient, WsProvider } from 'dedot';
+import { SubstrateApi } from 'dedot/chaintypes';
+import { $SignedBlock } from 'dedot/codecs';
+import { u8aToHex } from 'dedot/utils';
+import * as fs from 'node:fs';
+
+const decodeEvents = async (Client: typeof LegacyClient | typeof DedotClient, blockNumber: number) => {
+  const client = await LegacyClient.new(new WsProvider('wss://archive.chain.opentensor.ai:443'));
+  const blockHash = await client.rpc.chain_getBlockHash(blockNumber);
+  if (!blockHash) {
+    throw new Error('Block hash not found');
+  }
+
+  const clientAt = await client.at(blockHash);
+
+  const events = await clientAt.query.system.events();
+  console.log(`Received ${events.length} events via ${Client.name} at block ${blockNumber}`);
+
+  await client.disconnect();
+};
+
+await decodeEvents(LegacyClient, 6523565);
+await decodeEvents(DedotClient, 6523565);
+
+await decodeEvents(LegacyClient, 6523566);
+await decodeEvents(DedotClient, 6523566);
+
+await decodeEvents(LegacyClient, 6523567);
+await decodeEvents(DedotClient, 6523567);

--- a/packages/api/src/client/DedotClient.ts
+++ b/packages/api/src/client/DedotClient.ts
@@ -1,4 +1,4 @@
-import { $H256, $RuntimeVersion, BlockHash, PortableRegistry } from '@dedot/codecs';
+import { $H256, $Header, $RuntimeVersion, BlockHash, Hash, PortableRegistry } from '@dedot/codecs';
 import type { JsonRpcProvider } from '@dedot/providers';
 import { u32 } from '@dedot/shape';
 import { GenericSubstrateApi, RpcV2, RpcVersion, VersionedGenericSubstrateApi } from '@dedot/types';
@@ -247,24 +247,42 @@ export class DedotClient<ChainApi extends VersionedGenericSubstrateApi = Substra
     const cached = this._apiAtCache.get<ISubstrateClientAt<ChainApiAt>>(hash);
     if (cached) return cached;
 
-    let targetVersion: SubstrateRuntimeVersion;
+    let parentVersion: SubstrateRuntimeVersion;
+    let parentHash: Hash;
 
     // Try to get block info from ChainHead first (for pinned blocks)
     const targetBlock = this.chainHead.findBlock(hash);
     if (targetBlock) {
-      targetVersion = targetBlock.runtime as SubstrateRuntimeVersion;
-      if (!targetVersion) {
-        // fallback to fetching on-chain runtime if we can't find it in the block
-        targetVersion = this.toSubstrateRuntimeVersion(await this.callAt(hash).core.version());
+      if (hash === this.genesisHash) {
+        parentHash = hash;
+        parentVersion = targetBlock.runtime!;
+      } else {
+        parentHash = targetBlock.parent;
+        const parentBlock = this.chainHead.findBlock(parentHash);
+        parentVersion = parentBlock?.runtime as SubstrateRuntimeVersion;
+      }
+
+      // fallback to fetching on-chain runtime if we can't find it in the block
+      if (!parentVersion) {
+        parentVersion = this.toSubstrateRuntimeVersion(await this.callAt(parentHash).core.version());
       }
     } else {
       // Block not pinned, try via Archive fallback if supported
       if (this._archive && (await this._archive.supported())) {
         try {
+          if (hash === this.genesisHash) {
+            parentHash = hash;
+          } else {
+            const rawHeader = await this._archive.header(hash);
+            assert(rawHeader, `Header for block ${hash} not found`);
+            const header = $Header.tryDecode(rawHeader);
+            parentHash = header.parentHash;
+          }
+
           // Fetch runtime version via Archive
-          const runtimeRaw = await this._archive.call('Core_version', '0x', hash);
+          const runtimeRaw = await this._archive.call('Core_version', '0x', parentHash);
           assert(runtimeRaw, 'Runtime Version Not Found');
-          targetVersion = this.toSubstrateRuntimeVersion($RuntimeVersion.tryDecode(runtimeRaw));
+          parentVersion = this.toSubstrateRuntimeVersion($RuntimeVersion.tryDecode(runtimeRaw));
         } catch (error) {
           throw new DedotError(`Unable to fetch runtime version for block ${hash}: ${error}`);
         }
@@ -275,8 +293,8 @@ export class DedotClient<ChainApi extends VersionedGenericSubstrateApi = Substra
 
     let metadata = this.metadata;
     let registry: any = this.registry;
-    if (targetVersion && targetVersion.specVersion !== this.runtimeVersion.specVersion) {
-      metadata = await this.fetchMetadata(hash, targetVersion);
+    if (parentVersion && parentVersion.specVersion !== this.runtimeVersion.specVersion) {
+      metadata = await this.fetchMetadata(parentHash, parentVersion);
       registry = new PortableRegistry<ChainApiAt['types']>(metadata.latest, this.options.hasher);
     }
 
@@ -285,7 +303,7 @@ export class DedotClient<ChainApi extends VersionedGenericSubstrateApi = Substra
       atBlockHash: hash,
       options: this.options,
       genesisHash: this.genesisHash,
-      runtimeVersion: targetVersion,
+      runtimeVersion: parentVersion,
       metadata,
       registry,
       rpc: this.rpc,


### PR DESCRIPTION
We should use runtime metadata of parent block for .at instances.

Thank you @antlerminator for reporting the issue.